### PR TITLE
Get CI green across extended Ruby matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.4", "head"]
+        ruby: ["3.3", "3.4", "4.0", "head"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.3", "3.4", "head"]
+        ruby: ["3.3", "3.4", "4.0", "head"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/docs/HOTCELL-SPEC.md
+++ b/docs/HOTCELL-SPEC.md
@@ -1836,11 +1836,11 @@ Invariant 1 is withdrawn — see the invariants above — so there is nothing to
   see the same `$HOME`; two running concurrently see different ones.
 - The deadline, and **not with `sleep`**. A Ruby `sleep` is interruptible, so a deadline test built on one
   passes against a self-enforcing implementation that cannot actually work. Block the worker where Ruby cannot
-  reach it and assert it is answered `killed`. Measured across the standard library: `sleep`, a Ruby spin loop
-  and `Zlib::Inflate` are all interruptible, and `Integer#**` is not — `3 ** 40_000_000` runs for about seven
-  seconds straight through a fifty-millisecond `Timeout`. That lets the cell's own suite hold this with no
-  tool installed. Assert the premise in the test, so a Ruby that adds an interrupt check to that path
-  reports it rather than quietly weakening the test. Two things are being
+  reach it and assert it is answered `killed`. `Thread.handle_interrupt(Exception => :never) { sleep }` does
+  that: `Timeout` raises asynchronously, and the deferral holds the raise until the block ends, which is what
+  a thread inside a C extension does. That lets the cell's own suite hold this with no tool installed. Do not
+  build it on a long computation instead: `Integer#**` runs for seconds without GMP and finishes at once with
+  it, so the stand-in would depend on how the Ruby was built. Two things are being
   tested: that the supervisor kills it at all, and that it does so **promptly**, with no other request needed
   to trigger the reap. The naive reap-at-top-of-accept-loop implementation fails the second.
 - The deadline is per request, not per worker life: a worker that has already served several quick requests

--- a/hotcell-server/lib/hot_cell/test_operations.rb
+++ b/hotcell-server/lib/hot_cell/test_operations.rb
@@ -187,25 +187,16 @@ module HotCell
     #
     # A deadline test built on sleep passes against a self-enforcing implementation that could never work in
     # production, because Timeout raises at an interrupt checkpoint and a thread inside a C extension does
-    # not reach one until it returns. libvips is the real case; Integer#** is the one in the standard
-    # library. Measured: 3 ** 40_000_000 runs for 6.7 seconds straight through a 0.05 second Timeout, so a
-    # deadline test against it fails loudly rather than passing by finishing early.
+    # not reach one until it returns. libvips is the real case. Deferring the raise reproduces that on every
+    # Ruby and every build, which a long computation cannot: Integer#** takes seven seconds without GMP and
+    # a fraction of a second with it. SIGKILL is not deferrable, so the supervisor still gets through.
     class Uninterruptible < HotCell::Operation
       operation "test.uninterruptible"
-      EXPONENT = 40_000_000
-
-      # The premise, asserted rather than assumed. If a later Ruby adds an interrupt check to this path, the
-      # deadline tests should say so instead of quietly becoming weaker.
-      def self.blocks_through_a_timeout?
-        require "timeout"
-        Timeout.timeout(0.05) { 3**5_000_000 }
-        true
-      rescue Timeout::Error
-        false
-      end
+      SECONDS = 60
 
       def perform(_inputs, _outputs)
-        { digits: (3**EXPONENT).bit_length }
+        Thread.handle_interrupt(Exception => :never) { sleep SECONDS }
+        {}
       end
     end
 

--- a/hotcell-server/test/scheduling_test.rb
+++ b/hotcell-server/test/scheduling_test.rb
@@ -3,12 +3,6 @@
 require "test_helper"
 
 class SchedulingTest < HotCellServerTest
-  def setup
-    unless Fixtures::Uninterruptible.blocks_through_a_timeout?
-      skip "Integer#** is interruptible on this Ruby, so it no longer stands in for a C extension"
-    end
-  end
-
   # Two things are being tested. That the supervisor kills an overdue worker at all, and that it does so
   # promptly, with no other request needed to trigger the reap. A supervisor that only reaped at the top of
   # its accept loop would leave this caller waiting out its whole timeout, so the naive implementation
@@ -20,7 +14,7 @@ class SchedulingTest < HotCellServerTest
 
       failure = assert_failed "killed", response, cause: "deadline"
       assert_equal "KILL", failure.signal
-      assert_operator took, :<, 4, "the work itself takes 6.7s, so this was not a kill"
+      assert_operator took, :<, 4, "the work itself runs for a minute, so this was not a kill"
 
       # A killed worker cannot report anything, so the supervisor fills this in from fork to reap. It is an
       # upper bound rather than a measurement, and it is worth having: killed at 30s and killed at 0.2s are


### PR DESCRIPTION
### Motivation / Background

Every `ci` run on `master` has failed since the workflow was added. Five tests in
`hotcell-server/test/scheduling_test.rb` failed on every Ruby in the matrix.

`Fixtures::Uninterruptible` in `hotcell-server/lib/hot_cell/test_operations.rb`
stood in for a C extension by computing a large power:

    { digits: (3**EXPONENT).bit_length }

That runs for about seven seconds only on a Ruby built without GMP, which is how
the local rubies are built and is not how `ruby/setup-ruby` builds them. On the
CI rubies the fixture never pinned the worker: on 3.4 and later the power
finished well inside the deadline and the request was answered `ok`, and on 3.3
it exceeded the bignum size limit, returned a `Float`, and `bit_length` raised.

The premise check `blocks_through_a_timeout?` reported "uninterruptible" whenever
no `Timeout::Error` arrived. A build that finishes early raises no error either,
so the check could not tell the two apart and never skipped.

### Detail

Two changes.

The matrix gains Ruby 4.0, in both the `hotcell` job and the `activestorage` job.

The fixture defers the interrupt rather than outrunning it:

    Thread.handle_interrupt(Exception => :never) { sleep SECONDS }

`Timeout` raises asynchronously, and the deferral holds that raise until the
block ends — the same behavior as a thread inside a C extension, on every Ruby
and every build. `SIGKILL` is not deferrable, so the supervisor's kill still
lands. The premise check and the `setup` skip it guarded are gone, because the
property is now guaranteed rather than measured.

`rake hotcell` previously reported 5 failures on a GMP-linked Ruby 3.3 and 4 on
3.4. It now reports 304 runs, 0 failures, 0 skips on both a GMP build (3.3.10)
and a non-GMP build (4.0.6). The five tests also stop burning CPU; each now
blocks until the supervisor kills it.

### Additional information

`docs/HOTCELL-SPEC.md` stated the seven-second measurement as a fact about the
standard library. It now describes the deferral and records why a long
computation is the wrong stand-in.
