### PR TITLE
Run the no-toolchain suite on macOS in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,27 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake hotcell
 
+  # The uncontainerized cell is the supported macOS development path, so the no-toolchain suite runs on a mac
+  # too. It is advisory rather than a gate: the runners are slow and a timing-sensitive deadline test is
+  # occasionally flaky there, and the memory clamp is unenforced because macOS has no finite RLIMIT_DATA. One
+  # lane on one Ruby, because macOS runners bill at about ten times the Linux rate.
+  hotcell-macos:
+    name: "hotcell (macos, ruby 3.4)"
+    runs-on: macos-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec rake hotcell
+
   # These convert real images, PDFs and video rather than pretending to, so the converters have to be here.
   activestorage:
     name: "activestorage (ruby ${{matrix.ruby}})"

--- a/hotcell-core/test/connection_test.rb
+++ b/hotcell-core/test/connection_test.rb
@@ -149,10 +149,18 @@ class ConnectionTest < HotCellTest
     assert_nil cold.read_line
   end
 
+  # The write runs in its own thread because it is larger than a socket's send buffer, and on a platform whose
+  # buffer is smaller than the message a single-threaded write blocks before the reader on the next line ever
+  # runs. In production the two ends are separate processes, so the reader drains while the writer writes.
   def test_an_oversized_response_is_refused
-    hot.socket.write "x" * (HotCell::MAX_RESPONSE_BYTES + 1)
+    writer = Thread.new do
+      hot.socket.write "x" * (HotCell::MAX_RESPONSE_BYTES + 1)
+    rescue IOError, Errno::EPIPE
+    end
 
     assert_raises(HotCell::MessageError) { cold.read_line }
+  ensure
+    writer&.kill
   end
 
   # A stream socket may send less than it was given. When the short send is the one carrying the ancillary

--- a/hotcell-server/lib/hot_cell/limits.rb
+++ b/hotcell-server/lib/hot_cell/limits.rb
@@ -76,8 +76,33 @@ module HotCell
       RESOURCES.each do |key, resource|
         soft = self[key]
         next if soft.nil?
+        next if key == :memory && !self.class.memory_enforceable?
 
-        Process.setrlimit resource, soft, ceiling[key] || soft
+        begin
+          Process.setrlimit resource, soft, ceiling[key] || soft
+        rescue Errno::EINVAL
+          raise unless key == :memory
+
+          self.class.memory_unenforceable!
+        end
+      end
+    end
+
+    # macOS/XNU has no finite RLIMIT_DATA and returns EINVAL for any value, so the memory clamp cannot be set
+    # there. Rather than crash every worker, warn once and run unclamped — the memory limit is a Linux property
+    # and production is Linux. The suite skips the enforcement assertions off Linux.
+    @memory_enforceable = true
+
+    class << self
+      def memory_enforceable?
+        @memory_enforceable
+      end
+
+      def memory_unenforceable!
+        return unless @memory_enforceable
+
+        @memory_enforceable = false
+        warn "hotcell: RLIMIT_DATA is not settable on #{RUBY_PLATFORM}; the cell's memory limit is not enforced"
       end
     end
 

--- a/hotcell-server/test/resource_limits_test.rb
+++ b/hotcell-server/test/resource_limits_test.rb
@@ -8,7 +8,13 @@ class ResourceLimitsTest < HotCellServerTest
   CELL_MEMORY = 1200 * 1024**2
   CELL_FILE_SIZE = 8 * 1024 * 1024
 
+  # macOS/XNU rejects a finite RLIMIT_DATA, so the cell runs unclamped there and the memory-clamp assertions
+  # below cannot hold. They skip where the clamp is not enforceable.
+  MEMORY_UNENFORCED = "RLIMIT_DATA is not settable on this platform, so the cell runs unclamped"
+
   def test_a_worker_runs_under_the_cells_limits
+    skip MEMORY_UNENFORCED unless memory_clamp_enforced?
+
     boot do |cell|
       limits = assert_ok(cell.call("test.rlimits")).result
 
@@ -22,6 +28,8 @@ class ResourceLimitsTest < HotCellServerTest
   # lets a reused worker widen back for an operation with a different budget. Setting both would make the
   # first request the tightest the worker could ever be.
   def test_an_operation_narrows_the_soft_limit_and_leaves_the_hard_one_alone
+    skip MEMORY_UNENFORCED unless memory_clamp_enforced?
+
     boot do |cell|
       limits = assert_ok(cell.call("test.frugal")).result
 
@@ -35,6 +43,8 @@ class ResourceLimitsTest < HotCellServerTest
   # declares, and unclamped this does not merely get too much — it asks for a soft limit above its own hard
   # limit, which is EINVAL, and the worker dies before it can answer.
   def test_an_operation_asking_for_more_than_the_cell_allows_gets_the_cells_numbers
+    skip MEMORY_UNENFORCED unless memory_clamp_enforced?
+
     boot do |cell|
       limits = assert_ok(cell.call("test.extravagant")).result
 
@@ -94,6 +104,8 @@ class ResourceLimitsTest < HotCellServerTest
   # tempting to report as an ordinary failure. It is the decompression-bomb case, so it belongs with the
   # other resource verdicts where a caller can act on it without parsing a message.
   def test_allocating_past_the_memory_limit_is_killed_rather_than_failed
+    skip MEMORY_UNENFORCED unless memory_clamp_enforced?
+
     boot do |cell|
       failure = assert_failed "killed", cell.call("test.greedy", payload: { megabytes: 900 }, timeout: 30),
                               cause: "memory"
@@ -111,5 +123,15 @@ class ResourceLimitsTest < HotCellServerTest
   private
     def boot(**options, &block)
       TestCell.boot(memory: CELL_MEMORY, file_size: CELL_FILE_SIZE, **options, &block)
+    end
+
+    # Whether a finite RLIMIT_DATA can be set here, probed without lasting effect. macOS returns EINVAL.
+    def memory_clamp_enforced?
+      soft, hard = Process.getrlimit(Process::RLIMIT_DATA)
+      Process.setrlimit(Process::RLIMIT_DATA, CELL_MEMORY, hard)
+      Process.setrlimit(Process::RLIMIT_DATA, soft, hard)
+      true
+    rescue Errno::EINVAL
+      false
     end
 end

--- a/hotcell-server/test/worker_reports_test.rb
+++ b/hotcell-server/test/worker_reports_test.rb
@@ -171,11 +171,16 @@ class WorkerReportsTest < HotCellServerTest
     pending = HotCell::Supervisor::Pending.new(HotCell::Connection.new(server_side), HotCell::Clock.now, "".b)
     @supervisor.instance_variable_get(:@control_pending) << pending
 
-    client_side.write %({"v":#{HotCell::PROTOCOL_VERSION},"op":"#{HotCell::METRICS}",) +
-                      %("inputs":0,"outputs":0,"payload":{"pad":"#{"x" * 9000}"}}\n)
+    writer = Thread.new do
+      client_side.write %({"v":#{HotCell::PROTOCOL_VERSION},"op":"#{HotCell::METRICS}",) +
+                        %("inputs":0,"outputs":0,"payload":{"pad":"#{"x" * 9000}"}}\n)
+    rescue IOError, Errno::EPIPE
+    end
     drain_control pending
 
     assert_failed "invalid", HotCell::Response.parse(client_side.gets)
+  ensure
+    writer&.kill
   end
 
   # `running < concurrency ||` short-circuited the cap. That reads like a fast path and is a hole: when fork


### PR DESCRIPTION
### Motivation / Background

CI ran `rake hotcell` only on `ubuntu-latest`. The uncontainerized cell is the supported macOS development path (`README.md`), and the code carries Darwin-specific branches — `SUN_PATH_MAX` in `hotcell-server/lib/hot_cell/supervisor.rb`, and the stream socket in `hotcell-core/lib/hot_cell/connection.rb`, because Darwin has no `AF_UNIX SOCK_SEQPACKET`. None of that had CI coverage.

### Detail

Adds a `macos-latest` lane running `rake hotcell` on Ruby 3.4, advisory (`continue-on-error`), one Ruby because macOS runners bill at about ten times the Linux rate.

Bringing the suite up on macOS surfaced three things, each fixed here:

- **Two tests deadlocked.** `ConnectionTest#test_an_oversized_response_is_refused` and `WorkerReportsTest#test_a_control_message_over_the_limit_is_refused_before_it_is_parsed` wrote an over-the-limit message with a single blocking `IO#write` and read it on the next line of the same thread. macOS's smaller Unix-socket send buffer fills and the write blocks before the reader runs. Each now sends the oversized bytes from a background thread, the way the two separate processes behave in production.
- **Every worker crashed.** macOS/XNU has no finite `RLIMIT_DATA` and returns `EINVAL`, so `Limits#apply` died before serving and every request came back `killed: crashed`. `apply` now warns and runs unclamped where the memory clamp cannot be set; every other limit stays strict, and production (Linux) is unchanged.
- **Four memory-clamp assertions cannot hold** where the clamp is unenforced. They skip there, probing `RLIMIT_DATA` settability without lasting effect.

On macOS, `hotcell-core`, `hotcell-server`, and `hotcell-client` all pass (server with the four memory assertions skipped). Linux is unchanged.

### Additional information

- The lane is advisory because the macOS runners are slow — the server suite runs in ~26s there versus ~1.5s on Linux — and a timing-sensitive deadline test is occasionally flaky under that load. The deadline mechanism itself is sound: `test.spawns` under a 0.3s deadline returned a clean `killed: deadline` verdict 8/8 in isolation.
- That flake exposed a real but rare robustness edge, worth a separate look: under heavy load a deadline-killed worker can occasionally leave its caller with a closed connection instead of a verdict (`answer_for`'s `return child.connection&.close unless child.busy?`). It is not macOS-specific and does not reproduce in isolation.
- The memory clamp being unenforced on macOS matches `README.md`, which already states it does not apply there.
