### PR TITLE
Install poppler-utils so the Poppler previewer runs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install the converters
         run: |
           sudo apt-get update -qq
-          sudo apt-get install --no-install-recommends -y libvips42 mupdf-tools ffmpeg imagemagick
+          sudo apt-get install --no-install-recommends -y libvips42 mupdf-tools poppler-utils ffmpeg imagemagick
       - uses: ruby/setup-ruby@9eb537ca036ebaed86729dcb9309076e4c5c3b74 # v1.314.0
         with:
           ruby-version: "${{matrix.ruby}}"


### PR DESCRIPTION
`master` has been red since the Poppler previewer landed. The `activestorage`
job installs `libvips42 mupdf-tools ffmpeg imagemagick` but not `poppler-utils`,
so `pdftoppm` is absent and the two Poppler previewer tests fail with
`Errno::ENOENT` on every Ruby.

This adds `poppler-utils` to the converter install. Small, urgent — greens
`master`.
