### PR TITLE
Adopt ECS log formatting

### DIFF
--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -1,0 +1,95 @@
+# Log lines
+
+The cell writes one JSON object per line to stdout. Field names follow
+[ECS](https://www.elastic.co/guide/en/ecs/current/index.html), the schema the rest of the fleet's
+structured logs already speak. Anything ECS has no name for lives under the `hotcell` namespace, so
+no future ECS field can collide with ours.
+
+## The envelope
+
+Every line carries these five fields:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `@timestamp` | string | When it happened. UTC, ISO 8601, millisecond precision. |
+| `service.name` | string | Always `"hotcell"`. This is the routing key: the log collector selects our lines by it. |
+| `event.action` | string | Which event this is. The full list is below. |
+| `log.level` | string | `"INFO"`, `"WARN"` or `"ERROR"`. The emitter decides severity, not the collector, so adding an event never requires a collector change. |
+| `process.pid` | integer | The process the event is about: the worker's pid for `worker.*` events, the supervisor's own for `cell.*`. Absent where no process is the subject. |
+
+## Shared fields
+
+Where ECS has a name, we use it:
+
+| Field | Type | Used by |
+| --- | --- | --- |
+| `error.type` | string | Exception class name, wherever an exception is reported. |
+| `error.message` | string | The sanitized exception message beside `error.type`. |
+| `message` | string | Human-readable detail on events whose meaning needs prose (`cell.ptrace_scope_unknown`, `slot.uncleaned`, `worker.unreadable_report`). |
+| `event.outcome` | string | `"success"` or `"failure"`, on `request` only. |
+| `event.duration.ms` | number | Wall time of the thing that ended. This is the fleet's dialect (rails logs use `event.duration.ms`), not stock ECS (`event.duration` in nanoseconds). |
+| `process.exit_code` | integer | The worker's exit status, on `worker.reaped`. |
+
+Everything else is ours and sits under `hotcell.*`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `hotcell.slot` | integer | The slot number. On nearly every event. |
+| `hotcell.code` | string | The response code of a `request` (`"ok"`, `"failed"`, `"killed"`, ...). |
+| `hotcell.permanent` | boolean | Whether a `request` failure is permanent. |
+| `hotcell.cause` | string | Why a worker was killed (`"deadline"`, `"memory"`, `"fsize"`, ...). |
+| `hotcell.signal` | string | Signal name (`"SIGKILL"`, `"SIGSEGV"`, ...). ECS has no field for signals. |
+| `hotcell.served` | integer | Requests a worker served before it was reaped. |
+| `hotcell.home` | string | A slot's scratch directory. |
+| `hotcell.directory` | string | The cell's working directory, on `cell.boot`. |
+| `hotcell.operations` | array | Registered operation names, on `cell.boot`. |
+| `hotcell.configuration` | object | The full configuration inventory (same shape as `hotcell.describe`), on `cell.boot`. |
+| `hotcell.running` / `hotcell.queued` | integer | In-flight and queued requests, on `cell.stopping`. |
+| `hotcell.timing` | object | A request's phase timings: `queued_ms`, `perform_ms`, and any measured phases. |
+| `hotcell.deadline_s` / `hotcell.grace_s` / `hotcell.waited_s` | number | The limit that was hit, on the event that reports hitting it. |
+| `hotcell.path` | string | The file the cell could not verify, on `cell.ptrace_scope_unknown`. |
+
+## Events
+
+| `event.action` | `log.level` | Fields beyond the envelope |
+| --- | --- | --- |
+| `cell.boot` | INFO | `hotcell.directory`, `hotcell.operations`, `hotcell.configuration` |
+| `cell.stopping` | INFO | `hotcell.running`, `hotcell.queued` |
+| `cell.stopped` | INFO | — |
+| `cell.ptrace_scope_unknown` | ERROR | `hotcell.path`, `message` |
+| `request` | INFO | `hotcell.slot`, `hotcell.code`, `hotcell.permanent`, `event.outcome`, `event.duration.ms`, `hotcell.timing` |
+| `request.abandoned` | WARN | `hotcell.slot` |
+| `worker.forked` | INFO | `hotcell.slot` |
+| `worker.reaped` | INFO | `hotcell.slot`, `hotcell.served`, `hotcell.signal`, `process.exit_code` |
+| `worker.crashed` | ERROR | `hotcell.slot`, `error.type`, `error.message` |
+| `worker.killed` | WARN | `hotcell.slot`, `hotcell.cause`, `hotcell.signal`, `event.duration.ms` |
+| `worker.deadline` | WARN | `hotcell.slot`, `hotcell.deadline_s` |
+| `worker.lingered` | WARN | `hotcell.slot`, `hotcell.grace_s` |
+| `worker.unforkable` | ERROR | `hotcell.slot`, `error.type`, `error.message` |
+| `worker.undispatchable` | ERROR | `hotcell.slot`, `error.type` |
+| `worker.unreadable_report` | ERROR | `message` |
+| `control.abandoned` | WARN | `hotcell.waited_s` |
+| `control.unanswerable` | WARN | `error.type`, `error.message` |
+| `slot.uncleaned` | WARN | `hotcell.slot`, `hotcell.home`, `message` (boot sweep only) |
+| `slot.undiscarded` | WARN | `hotcell.slot`, `hotcell.home` |
+
+## Examples
+
+A request:
+
+```json
+{"@timestamp":"2026-08-14T21:05:28.252Z","service":{"name":"hotcell"},"event":{"action":"request","outcome":"success","duration":{"ms":9.6}},"log":{"level":"INFO"},"process":{"pid":83},"hotcell":{"slot":0,"code":"ok","permanent":null,"timing":{"queued_ms":0.4,"perform_ms":0.52}}}
+```
+
+A crash:
+
+```json
+{"@timestamp":"2026-08-14T21:05:29.107Z","service":{"name":"hotcell"},"event":{"action":"worker.crashed"},"log":{"level":"ERROR"},"process":{"pid":83},"error":{"type":"NoMethodError","message":"undefined method 'blur' for nil"},"hotcell":{"slot":0}}
+```
+
+## The contract with the collector
+
+The fleet's log collector routes on `service.name == "hotcell"`, sets the record timestamp from
+`@timestamp`, and takes severity from `log.level`. Those three fields are therefore load-bearing:
+renaming any of them silently drops or mislabels every cell log line in production. The rest of the
+schema can evolve freely.

--- a/hotcell-server/lib/hot_cell/log.rb
+++ b/hotcell-server/lib/hot_cell/log.rb
@@ -11,7 +11,36 @@ module HotCell
   #
   # This is the channel for everything no response can carry: deadline kills, reaps that found a signal,
   # boot checks, and queue high-water.
+  #
+  # Lines follow docs/LOGS.md: ECS field names, domain fields under the hotcell namespace. The fleet's
+  # collector routes on service.name, takes the record timestamp from @timestamp, and severity from
+  # log.level, so those three are load-bearing: renaming any of them silently drops or mislabels every
+  # cell log line in production.
   class Log
+    # Severity lives here rather than in the collector so that adding an event never needs a collector
+    # change. An event missing from this table logs as INFO rather than not at all.
+    LEVELS = {
+      "cell.boot" => "INFO",
+      "cell.stopping" => "INFO",
+      "cell.stopped" => "INFO",
+      "cell.ptrace_scope_unknown" => "ERROR",
+      "request" => "INFO",
+      "request.abandoned" => "WARN",
+      "worker.forked" => "INFO",
+      "worker.reaped" => "INFO",
+      "worker.crashed" => "ERROR",
+      "worker.killed" => "WARN",
+      "worker.deadline" => "WARN",
+      "worker.lingered" => "WARN",
+      "worker.unforkable" => "ERROR",
+      "worker.undispatchable" => "ERROR",
+      "worker.unreadable_report" => "ERROR",
+      "control.abandoned" => "WARN",
+      "control.unanswerable" => "WARN",
+      "slot.uncleaned" => "WARN",
+      "slot.undiscarded" => "WARN",
+    }.freeze
+
     def self.null
       new File.open(File::NULL, "w")
     end
@@ -46,7 +75,46 @@ module HotCell
       end
 
       def line(event, fields)
-        JSON.generate({ at: Time.now.utc.iso8601(3), event: event }.merge(fields)) << "\n"
+        JSON.generate(document(event, fields.dup)) << "\n"
+      end
+
+      def document(event, fields)
+        {
+          "@timestamp": Time.now.utc.iso8601(3),
+          service: { name: "hotcell" },
+          event: event_fields(event, fields),
+          log: { level: LEVELS.fetch(event, "INFO") },
+          **process_fields(fields),
+          **prose_fields(fields),
+          **({ hotcell: fields } unless fields.empty?).to_h,
+        }
+      end
+
+      def event_fields(event, fields)
+        { action: event }.tap do |result|
+          result[:outcome] = fields.delete(:outcome) if fields.key?(:outcome)
+          result[:duration] = { ms: fields.delete(:duration_ms) } if fields.key?(:duration_ms)
+        end
+      end
+
+      def process_fields(fields)
+        process = {
+          pid: fields.delete(:pid),
+          exit_code: fields.delete(:exit_code),
+        }.compact
+
+        process.empty? ? {} : { process: process }
+      end
+
+      # `message` beside an exception is that exception's message; alone it is the line's prose.
+      def prose_fields(fields)
+        if fields.key?(:error)
+          { error: { type: fields.delete(:error), message: fields.delete(:message) }.compact }
+        elsif fields.key?(:message)
+          { message: fields.delete(:message) }
+        else
+          {}
+        end
       end
   end
 end

--- a/hotcell-server/lib/hot_cell/supervisor.rb
+++ b/hotcell-server/lib/hot_cell/supervisor.rb
@@ -158,7 +158,7 @@ module HotCell
       trap_signals
 
       log.write "cell.boot", pid: Process.pid, directory: directory, operations: Registry.names,
-                             **configuration.to_h
+                             configuration: configuration.to_h
       self
     end
 
@@ -615,7 +615,7 @@ module HotCell
           # killed and no other request's deadline was enforced either.
           kill_group child
 
-          log.write "worker.deadline", pid: child.pid, slot: child.slot.number, deadline: child.deadline
+          log.write "worker.deadline", pid: child.pid, slot: child.slot.number, deadline_s: child.deadline
         end
       end
 
@@ -633,7 +633,7 @@ module HotCell
 
           kill_group child
 
-          log.write "worker.lingered", pid: child.pid, slot: child.slot.number, grace: Configuration::KILL_GRACE
+          log.write "worker.lingered", pid: child.pid, slot: child.slot.number, grace_s: Configuration::KILL_GRACE
         end
       end
 
@@ -712,7 +712,7 @@ module HotCell
           child.control.close
 
           log.write "worker.reaped", pid: pid, slot: child.slot.number, served: child.served,
-                                     signal: signal_name(status), status: status.exitstatus
+                                     signal: signal_name(status), exit_code: status.exitstatus
         end
       rescue Errno::ECHILD
         nil
@@ -734,7 +734,7 @@ module HotCell
         counters.record_kill cause
 
         log.write "worker.killed", pid: child.pid, slot: child.slot.number, cause: cause,
-                                   signal: signal_name(status), elapsed_ms: Clock.ms_since(child.dispatched_at)
+                                   signal: signal_name(status), duration_ms: Clock.ms_since(child.dispatched_at)
 
         answer child.connection,
                Failure.new(code: Codes::KILLED, cause: cause, signal: signal_name(status)),
@@ -822,7 +822,7 @@ module HotCell
       def verify_ptrace_scope!
         unless File.readable?(@ptrace_scope_path)
           return log.write "cell.ptrace_scope_unknown", path: @ptrace_scope_path,
-                                                        warning: "cannot verify that a worker is unable to read a sibling's memory"
+                                                        message: "cannot verify that a worker is unable to read a sibling's memory"
         end
 
         scope = File.read(@ptrace_scope_path).strip
@@ -854,7 +854,7 @@ module HotCell
           next if slot.prepare
 
           log.write "slot.uncleaned", slot: number, home: slot.home,
-                                      warning: "an earlier boot's files are still here"
+                                      message: "an earlier boot's files are still here"
         end
       end
 

--- a/hotcell-server/lib/hot_cell/test_cell.rb
+++ b/hotcell-server/lib/hot_cell/test_cell.rb
@@ -134,7 +134,7 @@ module HotCell
           nil
         end
 
-        parsed if parsed.is_a?(Hash) && parsed[:event] == event
+        parsed if parsed.is_a?(Hash) && parsed[:event].is_a?(Hash) && parsed[:event][:action] == event
       end
     end
 

--- a/hotcell-server/lib/hot_cell/worker.rb
+++ b/hotcell-server/lib/hot_cell/worker.rb
@@ -48,7 +48,7 @@ module HotCell
 
       exit! 0
     rescue Exception => error
-      log.write "worker.crashed", slot: slot.number, error: error.class.name,
+      log.write "worker.crashed", pid: Process.pid, slot: slot.number, error: error.class.name,
                                   message: Failure.sanitize(error.message)
       exit! 1
     end
@@ -125,7 +125,7 @@ module HotCell
       # the tree while remove_entry walks it. It cannot raise from an ensure, so it says so instead. One line
       # per request, from the ensure, because that is the attempt that knows the final state.
       def report_uncleaned
-        log.write "slot.uncleaned", slot: slot.number, home: slot.home
+        log.write "slot.uncleaned", pid: Process.pid, slot: slot.number, home: slot.home
       end
 
       def handle(line, received, timing)
@@ -243,7 +243,7 @@ module HotCell
 
         connection.write_line line_for(response)
       rescue SystemCallError, IOError
-        log.write "request.abandoned", slot: slot.number
+        log.write "request.abandoned", pid: Process.pid, slot: slot.number
       end
 
       def line_for(response)
@@ -255,9 +255,10 @@ module HotCell
       def record(response, timing)
         return if response.nil?
 
-        log.write "request", slot: slot.number, code: response.failure&.code || "ok",
-                             permanent: response.failure&.permanent?, elapsed_ms: timing.elapsed_ms,
-                             **response.timing
+        log.write "request", pid: Process.pid, slot: slot.number, code: response.failure&.code || "ok",
+                             permanent: response.failure&.permanent?,
+                             outcome: response.failure ? "failure" : "success",
+                             duration_ms: timing.elapsed_ms, timing: response.timing
       end
 
       def refuse(code, detail, timing, cause: nil)

--- a/hotcell-server/test/boot_test.rb
+++ b/hotcell-server/test/boot_test.rb
@@ -76,8 +76,8 @@ class BootTest < RegistryIsolatedTest
       cell.stop
       booted = cell.log_events("cell.boot").first
 
-      assert_equal 2, booted[:concurrency]
-      assert_includes booted[:operations], "test.uppercase"
+      assert_equal 2, booted.dig(:hotcell, :configuration, :concurrency)
+      assert_includes booted.dig(:hotcell, :operations), "test.uppercase"
     end
   end
 

--- a/hotcell-server/test/cell_test.rb
+++ b/hotcell-server/test/cell_test.rb
@@ -522,7 +522,7 @@ class CellTest < HotCellServerTest
       assert_failed "failed", cell.call("test.broken")
       cell.stop
 
-      codes = cell.log_events("request").map { |line| line[:code] }
+      codes = cell.log_events("request").map { |line| line.dig(:hotcell, :code) }
       assert_equal [ "ok", "failed" ], codes
     end
   end

--- a/hotcell-server/test/log_test.rb
+++ b/hotcell-server/test/log_test.rb
@@ -5,7 +5,78 @@ require "fcntl"
 
 # The log sink is a pipe to the container runtime, and the supervisor writes to it inside the loop that
 # enforces every request's deadline. A runtime that stops draining must not be able to park that loop.
+#
+# The line format is the schema in docs/LOGS.md. The fleet's log collector routes on service.name,
+# takes the record timestamp from @timestamp, and severity from log.level, so those three are
+# load-bearing: a rename silently drops or mislabels every cell log line in production.
 class LogTest < HotCellServerTest
+  def test_every_line_carries_the_envelope
+    line = written "worker.forked", pid: 42, slot: 3
+
+    assert_equal "hotcell", line.dig(:service, :name)
+    assert_equal "worker.forked", line.dig(:event, :action)
+    assert_equal "INFO", line.dig(:log, :level)
+    assert_equal 42, line.dig(:process, :pid)
+    assert_in_delta Time.now.utc, Time.iso8601(line[:"@timestamp"]), 5
+  end
+
+  def test_each_event_declares_its_own_level
+    assert_equal "ERROR", written("worker.crashed", slot: 0).dig(:log, :level)
+    assert_equal "WARN", written("worker.killed", slot: 0).dig(:log, :level)
+    assert_equal "INFO", written("request", slot: 0).dig(:log, :level)
+  end
+
+  def test_an_unknown_event_is_info_rather_than_unloggable
+    assert_equal "INFO", written("someday.new").dig(:log, :level)
+  end
+
+  def test_an_exception_becomes_error_type_and_error_message
+    line = written "worker.crashed", slot: 0, error: "NoMethodError", message: "undefined method"
+
+    assert_equal "NoMethodError", line.dig(:error, :type)
+    assert_equal "undefined method", line.dig(:error, :message)
+    assert_nil line[:message]
+  end
+
+  def test_prose_without_an_exception_becomes_the_message
+    line = written "slot.uncleaned", slot: 0, message: "an earlier boot's files are still here"
+
+    assert_equal "an earlier boot's files are still here", line[:message]
+    assert_nil line[:error]
+  end
+
+  def test_a_duration_and_an_outcome_land_under_event
+    line = written "request", slot: 0, code: "ok", outcome: "success", duration_ms: 9.6
+
+    assert_equal "success", line.dig(:event, :outcome)
+    assert_in_delta 9.6, line.dig(:event, :duration, :ms)
+  end
+
+  def test_an_exit_code_lands_under_process
+    line = written "worker.reaped", pid: 42, slot: 0, exit_code: 1
+
+    assert_equal 42, line.dig(:process, :pid)
+    assert_equal 1, line.dig(:process, :exit_code)
+  end
+
+  def test_domain_fields_nest_under_the_hotcell_namespace
+    line = written "worker.killed", pid: 42, slot: 3, cause: "memory", signal: "SIGKILL",
+                                    timing: { queued_ms: 0.4 }
+
+    assert_equal 3, line.dig(:hotcell, :slot)
+    assert_equal "memory", line.dig(:hotcell, :cause)
+    assert_equal "SIGKILL", line.dig(:hotcell, :signal)
+    assert_in_delta 0.4, line.dig(:hotcell, :timing, :queued_ms)
+    assert_nil line[:slot], "domain fields must not leak to the top level"
+  end
+
+  def test_fields_that_cannot_serialize_still_produce_a_line
+    line = written "worker.crashed", slot: 0, broken: Float::NAN
+
+    assert_equal "worker.crashed", line.dig(:event, :action)
+    assert_equal %w[slot broken], line.dig(:hotcell, :unloggable)
+  end
+
   def test_a_full_log_pipe_drops_the_line_rather_than_blocking_the_writer
     reader, writer = IO.pipe
     fill_pipe writer
@@ -22,6 +93,15 @@ class LogTest < HotCellServerTest
   end
 
   private
+    def written(event, **fields)
+      reader, writer = IO.pipe
+      HotCell::Log.new(writer).write event, **fields
+      writer.close
+      JSON.parse reader.read, symbolize_names: true
+    ensure
+      reader&.close
+    end
+
     # Fills the pipe so the next write has nowhere to go, and restores blocking mode so a naive write would
     # park on the full pipe rather than raise.
     def fill_pipe(writer)


### PR DESCRIPTION
Log lines now follow a standard, ECS, documented in `docs/LOGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)