### PR TITLE
Give every request a home no earlier one could have prepared

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -136,6 +136,15 @@ input that achieved code execution could reconfigure every later request on that
 the bound `max_requests_per_worker: 1` exists to hold. [ADR 0003](../adr/0003-remove-the-persistent-slot-home.md)
 records the reversal.
 
+The directory carries a fresh unpredictable name for every request, and that is what makes the removal a
+guarantee rather than an intention. A tool that reaches code execution runs as the user that owns the tree,
+so it can `chmod 0500` its own configuration directory and the slot directory around it, and both the
+worker's delete and the supervisor's rename then fail. Under a stable name the next request was handed the
+tree that had just refused to go. A name nothing has held before cannot be prepared, so a cleanup that fails
+costs disk until the container ends rather than the isolation the cell is for. The slot directory's mode is
+reasserted before each request for the same reason: it is the one predictable name, so it is the one an
+earlier request can lock, and the owner can always chmod its own directory.
+
 **Files are not isolated between concurrent workers, and cannot be.** Every worker runs as the same uid in
 one mount namespace, so a worker that reads another worker's scratch directory — by listing it, or through
 `/proc/<sibling>/fd/N` — gets that request's input and output bytes. Unlinking the scratch file does not

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -140,10 +140,16 @@ The directory carries a fresh unpredictable name for every request, and that is 
 guarantee rather than an intention. A tool that reaches code execution runs as the user that owns the tree,
 so it can `chmod 0500` its own configuration directory and the slot directory around it, and both the
 worker's delete and the supervisor's rename then fail. Under a stable name the next request was handed the
-tree that had just refused to go. A name nothing has held before cannot be prepared, so a cleanup that fails
-costs disk until the container ends rather than the isolation the cell is for. The slot directory's mode is
-reasserted before each request for the same reason: it is the one predictable name, so it is the one an
-earlier request can lock, and the owner can always chmod its own directory.
+tree that had just refused to go. A name no earlier request has held is not a name an earlier request could
+have prepared. A mode is also not a permission the process lost, so a cleanup that fails on one is retried
+after putting the mode back, and what a cleanup that still fails costs is disk rather than isolation.
+
+**That bounds what a finished request left behind, and not what a live process is doing.** Every worker runs
+as the same uid, and `0700` is that uid's own mode, so a concurrent sibling can write into a home as soon as
+it exists — and so can a `setsid` descendant of a request that has already answered, which process groups do
+not contain. The slot directory itself is a name a worker can rename aside and replace, and a pathname
+`chmod` follows what it finds. Those are the residuals below, and a fresh name does not close them: it
+closes the offline route, where nothing of the attacker's is still running.
 
 **Files are not isolated between concurrent workers, and cannot be.** Every worker runs as the same uid in
 one mount namespace, so a worker that reads another worker's scratch directory — by listing it, or through

--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -40,7 +40,7 @@ Everything else is ours and sits under `hotcell.*`:
 | `hotcell.cause` | string | Why a worker was killed (`"deadline"`, `"memory"`, `"fsize"`, ...). |
 | `hotcell.signal` | string | Signal name (`"SIGKILL"`, `"SIGSEGV"`, ...). ECS has no field for signals. |
 | `hotcell.served` | integer | Requests a worker served before it was reaped. |
-| `hotcell.home` | string | A request's scratch directory, inside its slot. |
+| `hotcell.home` | string | The scratch directory a cleanup could not clear: a request's `$HOME` from a worker, the slot directory from the supervisor. |
 | `hotcell.directory` | string | The cell's working directory, on `cell.boot`. |
 | `hotcell.operations` | array | Registered operation names, on `cell.boot`. |
 | `hotcell.configuration` | object | The full configuration inventory (same shape as `hotcell.describe`), on `cell.boot`. |
@@ -72,6 +72,7 @@ Everything else is ours and sits under `hotcell.*`:
 | `control.unanswerable` | WARN | `error.type`, `error.message` |
 | `slot.uncleaned` | WARN | `hotcell.slot`, `hotcell.home`, `message` (boot sweep only) |
 | `slot.undiscarded` | WARN | `hotcell.slot`, `hotcell.home` |
+| `slot.unswept` | WARN | `hotcell.slot`, `hotcell.home` |
 
 ## Examples
 

--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -40,7 +40,7 @@ Everything else is ours and sits under `hotcell.*`:
 | `hotcell.cause` | string | Why a worker was killed (`"deadline"`, `"memory"`, `"fsize"`, ...). |
 | `hotcell.signal` | string | Signal name (`"SIGKILL"`, `"SIGSEGV"`, ...). ECS has no field for signals. |
 | `hotcell.served` | integer | Requests a worker served before it was reaped. |
-| `hotcell.home` | string | A slot's scratch directory. |
+| `hotcell.home` | string | A request's scratch directory, inside its slot. |
 | `hotcell.directory` | string | The cell's working directory, on `cell.boot`. |
 | `hotcell.operations` | array | Registered operation names, on `cell.boot`. |
 | `hotcell.configuration` | object | The full configuration inventory (same shape as `hotcell.describe`), on `cell.boot`. |

--- a/hotcell-client/test/two_cells_test.rb
+++ b/hotcell-client/test/two_cells_test.rb
@@ -13,8 +13,10 @@ require "test_helper"
 class TwoCellsTest < HotCellClientTest
   def test_a_client_reaches_the_cell_it_named
     with_two_cells do |images, documents|
-      assert_equal File.join(images.workspace, "0", "home"), Thumbnail.perform_in_hotcell([], [], {})[:home]
-      assert_equal File.join(documents.workspace, "0", "home"), Preview.perform_in_hotcell([], [], {})[:home]
+      assert_equal File.join(images.workspace, "0"),
+                   File.dirname(Thumbnail.perform_in_hotcell([], [], {})[:home])
+      assert_equal File.join(documents.workspace, "0"),
+                   File.dirname(Preview.perform_in_hotcell([], [], {})[:home])
     end
   end
 

--- a/hotcell-server/lib/hot_cell/slot.rb
+++ b/hotcell-server/lib/hot_cell/slot.rb
@@ -26,12 +26,18 @@ module HotCell
   # the directory runs as the user that owns it: `chmod 0500` on a directory it has written makes its own
   # configuration unremovable, and the same mode on the slot directory makes it unrenameable too. Both
   # cleanups answer false and both callers log — and a stable name then handed the next request the tree
-  # that had just refused to go. A name nothing has used before cannot be prepared, so a cleanup that fails
-  # now costs disk until the container ends rather than the isolation the cell is for.
+  # that had just refused to go. A name no earlier request has held is not a name an earlier request could
+  # have prepared, so what a failed cleanup now costs is disk rather than the isolation the cell is for.
   #
-  # The mode of the slot directory is reasserted for the same reason. It is the one directory whose name is
-  # predictable, so it is the one an earlier request can lock; the owner can always chmod its own directory,
-  # so the repair always works.
+  # The mode of the slot directory is reasserted for the same reason. It is the one name here that is
+  # predictable, so it is the one an earlier request can lock, and a mode on a directory this uid owns is
+  # ours to put back.
+  #
+  # **This bounds what an earlier request left behind, and not what a live one is doing.** Workers share a
+  # uid and `0700` is the owner's own mode, so a concurrent sibling — or a `setsid` descendant of a finished
+  # request, which process groups do not contain — can still write into a home the moment it exists. The
+  # slot directory itself can be renamed aside and replaced, and `chmod` follows what it finds. Both are the
+  # residuals `docs/DESIGN.md` records under worker isolation, and neither is closed here.
   #
   # There is one directory per request and not two. A request's staged inputs and outputs are named inside
   # `$HOME` rather than in a scratch directory of their own, because the two had the same lifetime and the
@@ -74,12 +80,10 @@ module HotCell
     # rescues anything and a raise stops the cell with every request it holds.
     def remove_home
       return true if home.nil?
+      return false unless remove_tree(home)
 
-      FileUtils.remove_entry home if Dir.exist?(home)
       self.home = nil
       true
-    rescue SystemCallError
-      false
     end
 
     # **The supervisor renames rather than deletes, and that is a scheduling decision.**
@@ -118,20 +122,50 @@ module HotCell
     # Nothing here is created at boot, because nothing survives a request. This only clears what an earlier
     # boot left behind — the whole slot directory, since the names inside it are an earlier boot's and not
     # this one's to reconstruct.
+    #
+    # `Dir.exist?` is not the guard, because it follows symlinks and answers false for a dangling one. An
+    # entry a tool left in the slot's place is exactly what this has to remove, and it used to survive the
+    # sweep and raise from every later `make_home`.
     def prepare
-      FileUtils.remove_entry directory if Dir.exist?(directory)
-      true
-    rescue SystemCallError
-      false
+      remove_tree directory
     end
 
     # Unlinks whatever discard_home renamed out of the way. Partial progress is fine: a sweep killed
     # part-way leaves fewer entries for the next one, so this converges rather than repeating.
     def sweep
-      Dir.glob(File.join(directory, "discarded-*")).each { |path| FileUtils.remove_entry path }
-      true
+      Dir.glob(File.join(directory, "discarded-*")).map { |path| remove_tree(path) }.all?
     rescue SystemCallError
+      # The glob itself can fail, because the slot directory is a name a tool can replace — a symlink loop
+      # in its place answers ELOOP here rather than for any one entry. This runs from the worker's ensure,
+      # where a raise would replace the caller's response with a crash.
       false
     end
+
+    private
+      # **A mode is the only thing a tool needs to make its own tree unremovable, and a mode on a tree this
+      # uid owns is ours to put back.** `chmod 0500` on a directory a conversion wrote is enough to fail the
+      # recursive delete underneath it, and the delete failing used to be the end of it: one tree per
+      # request stayed on the tmpfs until the container ended. The repair is not a permission the process
+      # gains, it is one it never lost.
+      #
+      # Repair only after a failure, never before, so the common request pays for a walk of its own tree
+      # once rather than twice. `force:` on the chmod because a partial repair that removes most of the tree
+      # is better than none, and the remove that follows is what reports the outcome either way.
+      def remove_tree(path)
+        return true unless File.exist?(path) || File.symlink?(path)
+
+        FileUtils.remove_entry path
+        true
+      rescue SystemCallError
+        repair_and_remove path
+      end
+
+      def repair_and_remove(path)
+        FileUtils.chmod_R 0o700, path, force: true
+        FileUtils.remove_entry path
+        true
+      rescue SystemCallError
+        false
+      end
   end
 end

--- a/hotcell-server/lib/hot_cell/slot.rb
+++ b/hotcell-server/lib/hot_cell/slot.rb
@@ -11,8 +11,7 @@ module HotCell
   #
   # **A slot has one directory per request and it is that request's `$HOME`.** It is created when the
   # request starts and removed when the request ends, so nothing a tool writes under `$HOME` reaches the
-  # next request on this slot. The name is stable and the directory behind it is not, which is why a
-  # reused worker reports the same path twice.
+  # next request on this slot.
   #
   # This directory used to survive, to give a tool with an expensive per-user profile a warm one. That is
   # withdrawn. What a tool reads from `$HOME` is configuration, and for the toolchains a cell carries
@@ -22,23 +21,42 @@ module HotCell
   # `max_requests_per_worker: 1` is supposed to hold. adr/0003 records the reversal and adr/0002 the
   # reasoning it supersedes.
   #
-  # There is one directory and not two. A request's staged inputs and outputs are named inside `$HOME`
-  # rather than in a scratch directory of their own, because the two had the same lifetime and the same
-  # owner once the home stopped surviving. Staging used to create its directory on demand, which is what
-  # kept a descriptor-only operation from paying for one; `$HOME` has to exist for every request either
-  # way, so that laziness bought nothing and is gone with it.
+  # **The name is fresh for every request, and that is what makes the removal above a guarantee rather than
+  # an intention.** A stable name only holds while the deletion behind it works, and the tool that filled
+  # the directory runs as the user that owns it: `chmod 0500` on a directory it has written makes its own
+  # configuration unremovable, and the same mode on the slot directory makes it unrenameable too. Both
+  # cleanups answer false and both callers log — and a stable name then handed the next request the tree
+  # that had just refused to go. A name nothing has used before cannot be prepared, so a cleanup that fails
+  # now costs disk until the container ends rather than the isolation the cell is for.
+  #
+  # The mode of the slot directory is reasserted for the same reason. It is the one directory whose name is
+  # predictable, so it is the one an earlier request can lock; the owner can always chmod its own directory,
+  # so the repair always works.
+  #
+  # There is one directory per request and not two. A request's staged inputs and outputs are named inside
+  # `$HOME` rather than in a scratch directory of their own, because the two had the same lifetime and the
+  # same owner once the home stopped surviving. Staging used to create its directory on demand, which is
+  # what kept a descriptor-only operation from paying for one; `$HOME` has to exist for every request
+  # either way, so that laziness bought nothing and is gone with it.
   #
   # The filesystem behaviour belongs here rather than in the two processes that call it. The directory is
   # removed from both — the worker before it answers, the supervisor at finish and at reap — so the guard
   # and the swallowed SystemCallError are a rule that has to hold on both sides of a fork, and it had a
   # copy on each.
-  Slot = Struct.new(:number, :home) do
+  Slot = Struct.new(:number, :directory, :home) do
     def self.build(workspace, number)
-      new number, File.join(workspace, number.to_s, "home")
+      new number, File.join(workspace, number.to_s)
     end
 
+    # A name no request has held before, so nothing an earlier one did to the tree it was given reaches this
+    # one. The suffix is random rather than a counter for the reason the discarded name's is: the previous
+    # request could write to this directory, and a predictable name is one it can pre-create.
     def make_home
-      FileUtils.mkdir_p home, mode: 0o700
+      FileUtils.mkdir_p directory, mode: 0o700
+      FileUtils.chmod 0o700, directory
+
+      self.home = File.join(directory, "home-#{SecureRandom.hex(8)}")
+      Dir.mkdir home, 0o700
       home
     end
 
@@ -55,7 +73,10 @@ module HotCell
     # response with a crash, and the supervisor calls discard_home from finish and reap, where nothing above
     # rescues anything and a raise stops the cell with every request it holds.
     def remove_home
+      return true if home.nil?
+
       FileUtils.remove_entry home if Dir.exist?(home)
+      self.home = nil
       true
     rescue SystemCallError
       false
@@ -73,31 +94,41 @@ module HotCell
     # where the unlinking costs nobody's latency.
     #
     # The destination carries a random suffix rather than a counter, because the tool that filled the
-    # directory runs as this user and can write to the slot's workspace. A predictable name lets it
+    # directory runs as this user and can write to the slot's directory. A predictable name lets it
     # pre-create a colliding entry, fail the rename, and send the supervisor into the recursive delete the
     # rename exists to avoid. On any rename failure the tree is left where it is, for a later worker's own
     # cleanup to remove off the hot path. The supervisor never deletes a tree inline, whatever goes wrong.
+    # It renames what is there rather than the name it is holding, because the supervisor is the caller that
+    # matters and it does not know the name. `home` is assigned in the worker after the fork, so the
+    # supervisor's copy of the slot is still nil when it discards a killed worker's tree. At most one worker
+    # holds a slot at a time, so everything matching `home-*` under it is that worker's and nobody else's.
     def discard_home
-      return true unless Dir.exist?(home)
+      FileUtils.chmod 0o700, directory if Dir.exist?(directory)
 
-      File.rename home, "#{home}.discarded-#{Process.pid}-#{SecureRandom.hex(8)}"
+      Dir.glob(File.join(directory, "home-*")).each do |path|
+        File.rename path, File.join(directory, "discarded-#{Process.pid}-#{SecureRandom.hex(8)}")
+      end
+
+      self.home = nil
       true
     rescue SystemCallError
       false
     end
 
     # Nothing here is created at boot, because nothing survives a request. This only clears what an earlier
-    # boot left behind.
+    # boot left behind — the whole slot directory, since the names inside it are an earlier boot's and not
+    # this one's to reconstruct.
     def prepare
-      # Both, rather than short-circuiting: a home that could not be removed must not stop the sweep.
-      cleared = remove_home
-      sweep && cleared
+      FileUtils.remove_entry directory if Dir.exist?(directory)
+      true
+    rescue SystemCallError
+      false
     end
 
     # Unlinks whatever discard_home renamed out of the way. Partial progress is fine: a sweep killed
     # part-way leaves fewer entries for the next one, so this converges rather than repeating.
     def sweep
-      Dir.glob("#{home}.discarded-*").each { |path| FileUtils.remove_entry path }
+      Dir.glob(File.join(directory, "discarded-*")).each { |path| FileUtils.remove_entry path }
       true
     rescue SystemCallError
       false

--- a/hotcell-server/lib/hot_cell/supervisor.rb
+++ b/hotcell-server/lib/hot_cell/supervisor.rb
@@ -569,9 +569,10 @@ module HotCell
       # the random suffix exists because a tool running as this user can pre-create a colliding name, so a
       # rename that fails is the shape of that attempt as well as of an ordinary error.
       def discard(child)
+        home = child.slot.home
         return if child.slot.discard_home
 
-        log.write "slot.undiscarded", pid: child.pid, slot: child.slot.number, home: child.slot.home
+        log.write "slot.undiscarded", pid: child.pid, slot: child.slot.number, home: home
       end
 
       def unreadable_report(child, message)
@@ -860,7 +861,7 @@ module HotCell
           slot = Slot.build(workspace, number)
           next if slot.prepare
 
-          log.write "slot.uncleaned", slot: number, home: slot.home,
+          log.write "slot.uncleaned", slot: number, home: slot.directory,
                                       message: "an earlier boot's files are still here"
         end
       end

--- a/hotcell-server/lib/hot_cell/supervisor.rb
+++ b/hotcell-server/lib/hot_cell/supervisor.rb
@@ -568,11 +568,13 @@ module HotCell
       # off the hot path, because the supervisor must never delete one inline. It is not tolerated silently:
       # the random suffix exists because a tool running as this user can pre-create a colliding name, so a
       # rename that fails is the shape of that attempt as well as of an ordinary error.
+      # The slot directory rather than the request's home, because the supervisor does not know the home. It
+      # is named in the worker after the fork, so this copy of the slot holds nil for the whole life of the
+      # child — and logging it said `null` on every failure, which is worse than saying nothing.
       def discard(child)
-        home = child.slot.home
         return if child.slot.discard_home
 
-        log.write "slot.undiscarded", pid: child.pid, slot: child.slot.number, home: home
+        log.write "slot.undiscarded", pid: child.pid, slot: child.slot.number, home: child.slot.directory
       end
 
       def unreadable_report(child, message)

--- a/hotcell-server/lib/hot_cell/worker.rb
+++ b/hotcell-server/lib/hot_cell/worker.rb
@@ -74,12 +74,17 @@ module HotCell
         received = []
         response = nil
 
-        # Before the request rather than at boot, and one directory rather than two. A tool reads its
-        # configuration from $HOME and that configuration is executable, so a home that outlived the request
-        # let one compromised conversion reconfigure every later one on this slot. adr/0003.
-        ENV["HOME"] = slot.make_home
-
         begin
+          # Before the request rather than at boot, and one directory rather than two. A tool reads its
+          # configuration from $HOME and that configuration is executable, so a home that outlived the
+          # request let one compromised conversion reconfigure every later one on this slot. adr/0003.
+          #
+          # Inside the begin, because a home that cannot be created is a broken deployment and answers
+          # `failed`, which is transient. Outside it the raise skipped every response path and reached
+          # `run`, which exits the worker — after this ensure had already reported idle `"ok"`, counting a
+          # success for a request that never ran.
+          ENV["HOME"] = slot.make_home
+
           line, received = connection.receive_message
           response = if line.nil?
             # The caller closed before sending a request. Transient, so it is never written against a blob,
@@ -115,8 +120,8 @@ module HotCell
         # staging, where it would spend the next request's deadline on the previous request's mess. Here the
         # caller already has its response, and `report_idle` is what makes this worker available — so the
         # supervisor will not dispatch into a worker that is still sweeping.
-        slot.sweep
         report_uncleaned home unless swept
+        report_unswept unless slot.sweep
         report_idle response&.failure&.code
       end
 
@@ -126,6 +131,13 @@ module HotCell
       # per request, from the ensure, because that is the attempt that knows the final state.
       def report_uncleaned(home)
         log.write "slot.uncleaned", pid: Process.pid, slot: slot.number, home: home
+      end
+
+      # The other half of the same fact. A sweep removes what the supervisor renamed out of the way after a
+      # killed request, and its failure was the one cleanup outcome nobody said anything about — so a slot
+      # accumulating one tree per request looked exactly like a slot that was clean.
+      def report_unswept
+        log.write "slot.unswept", pid: Process.pid, slot: slot.number, home: slot.directory
       end
 
       def handle(line, received, timing)

--- a/hotcell-server/lib/hot_cell/worker.rb
+++ b/hotcell-server/lib/hot_cell/worker.rb
@@ -40,7 +40,6 @@ module HotCell
     # It swallows nothing: `exit! 1` runs whatever was caught.
     def run
       configuration.limits.apply
-      ENV["HOME"] = slot.home
 
       while (dispatch = await_dispatch)
         serve(*dispatch)
@@ -78,7 +77,7 @@ module HotCell
         # Before the request rather than at boot, and one directory rather than two. A tool reads its
         # configuration from $HOME and that configuration is executable, so a home that outlived the request
         # let one compromised conversion reconfigure every later one on this slot. adr/0003.
-        slot.make_home
+        ENV["HOME"] = slot.make_home
 
         begin
           line, received = connection.receive_message
@@ -107,6 +106,7 @@ module HotCell
       ensure
         received.each(&:close)
         connection.close
+        home = slot.home
         swept = slot.remove_home
 
         # After the answer and before reporting idle, which is the only window where this costs nobody. How
@@ -116,7 +116,7 @@ module HotCell
         # caller already has its response, and `report_idle` is what makes this worker available — so the
         # supervisor will not dispatch into a worker that is still sweeping.
         slot.sweep
-        report_uncleaned unless swept
+        report_uncleaned home unless swept
         report_idle response&.failure&.code
       end
 
@@ -124,8 +124,8 @@ module HotCell
       # after the caller has been told the request is over, and a sibling worker can cause it by writing into
       # the tree while remove_entry walks it. It cannot raise from an ensure, so it says so instead. One line
       # per request, from the ensure, because that is the attempt that knows the final state.
-      def report_uncleaned
-        log.write "slot.uncleaned", pid: Process.pid, slot: slot.number, home: slot.home
+      def report_uncleaned(home)
+        log.write "slot.uncleaned", pid: Process.pid, slot: slot.number, home: home
       end
 
       def handle(line, received, timing)

--- a/hotcell-server/test/cell_test.rb
+++ b/hotcell-server/test/cell_test.rb
@@ -484,14 +484,17 @@ class CellTest < HotCellServerTest
   end
 
   # The removal is what closes the window where a sibling worker reads this request's staged bytes, and it
-  # runs from an ensure where it cannot raise. It used to swallow the failure, so the bytes stayed on the
-  # shared tmpfs after the caller had been told the request was over, and nothing anywhere said so.
-  def test_a_home_that_cannot_be_removed_is_reported
+  # runs from an ensure where it cannot raise. A tool needs nothing but a mode to block it, and a mode on a
+  # tree this uid owns is one the worker puts back rather than gives up on — so the bytes go, and there is
+  # nothing to report. `slot.uncleaned` is for a removal that repair could not rescue.
+  def test_a_home_a_tool_tried_to_lock_open_is_removed_anyway
     cell = TestCell.boot
-    assert_ok cell.call("test.unremovable_home")
+    blocked = assert_ok(cell.call("test.unremovable_home")).result[:blocked]
 
-    # Polled, because the worker writes this from its ensure, after the caller already has the answer.
-    assert_equal 1, wait_for_event(cell, "slot.uncleaned").size, "the failed removal was silent: #{cell.log}"
+    cell.stop
+
+    refute Dir.exist?(File.dirname(blocked)), "the tree a mode blocked is still on the tmpfs"
+    assert_empty cell.log_events("slot.uncleaned"), "a removal that succeeded was reported as a failure"
   ensure
     # Stop the cell first: it is still sweeping, so a directory found by the glob can be gone by the chmod.
     # Then hand write permission back wherever the blocked directory landed, because the supervisor renames

--- a/hotcell-server/test/cell_test.rb
+++ b/hotcell-server/test/cell_test.rb
@@ -415,16 +415,19 @@ class CellTest < HotCellServerTest
   # unlinking lands on the next worker for this slot, which has a deadline of its own.
   def test_a_killed_workers_files_are_taken_out_of_the_way_rather_than_deleted_in_the_loop
     slot = HotCell::Slot.build(Dir.mktmpdir("hotcell-slot"), 0)
-    FileUtils.mkdir_p File.join(slot.make_home, "deep")
+    home = slot.make_home
+    FileUtils.mkdir_p File.join(home, "deep")
 
     slot.discard_home
 
-    refute Dir.exist?(slot.home), "the home path is free for the next request"
-    assert_equal 1, Dir.glob("#{slot.home}.discarded-*").size, "the tree is still there, out of the way"
+    refute Dir.exist?(home), "the directory should have been renamed away"
+    discarded = File.join(slot.directory, "discarded-*")
+
+    assert_equal 1, Dir.glob(discarded).size, "the tree is still there, out of the way"
 
     slot.sweep
 
-    assert_empty Dir.glob("#{slot.home}.discarded-*"), "a worker sweeps it once nobody is waiting"
+    assert_empty Dir.glob(discarded), "a worker sweeps it once nobody is waiting"
   end
 
   # The API takes several outputs and success was inferred from their total size, so writing the first and
@@ -449,7 +452,8 @@ class CellTest < HotCellServerTest
       with_files do |source, destination|
         assert_ok cell.call("test.uppercase", inputs: [ source ], outputs: [ destination ])
 
-        refute_path_exists File.join(cell.workspace, "0", "home")
+        assert_empty Dir.glob(File.join(cell.workspace, "0", "home-*")),
+                     "the request's home is still on the tmpfs after the answer"
       end
     end
   end
@@ -458,7 +462,9 @@ class CellTest < HotCellServerTest
     TestCell.boot do |cell|
       result = assert_ok(cell.call("test.whoami")).result
 
-      assert_equal File.join(cell.workspace, "0", "home"), result[:home]
+      assert_equal File.join(cell.workspace, "0"), File.dirname(result[:home])
+      assert_match(/\Ahome-[0-9a-f]{16}\z/, File.basename(result[:home]),
+                   "a request's home should carry a name no earlier request could have prepared")
     end
   end
 

--- a/hotcell-server/test/environment_test.rb
+++ b/hotcell-server/test/environment_test.rb
@@ -34,7 +34,10 @@ class EnvironmentTest < HotCellServerTest
       TestCell.boot do |cell|
         seen = assert_ok(cell.call("test.environment", payload: { canary: CANARY })).result[:seen]
 
-        assert_includes seen, "HOME=#{File.join(cell.workspace, "0", "home")}"
+        home = seen.grep(/\AHOME=/).first.delete_prefix("HOME=")
+
+        assert_equal File.join(cell.workspace, "0"), File.dirname(home)
+        assert_match(/\Ahome-[0-9a-f]{16}\z/, File.basename(home))
       end
     end
   end

--- a/hotcell-server/test/scheduling_test.rb
+++ b/hotcell-server/test/scheduling_test.rb
@@ -125,14 +125,15 @@ class SchedulingTest < HotCellServerTest
     end
   end
 
-  # The slot is what a reused worker keeps, and the home is named after it — so the path is the same one
-  # twice while the directory behind it is not. What does not carry across is held in cell_test.rb.
-  def test_a_reused_worker_keeps_its_slot
+  # A reused worker keeps its slot and does not keep its home: the two requests run in the same numbered
+  # directory under two names, because a name an earlier request held is one it could have prepared. What
+  # does not carry across is held in cell_test.rb.
+  def test_a_reused_worker_keeps_its_slot_and_not_its_home
     TestCell.boot(max_requests_per_worker: 2, concurrency: 1) do |cell|
       homes = 2.times.map { assert_ok(cell.call("test.whoami")).result[:home] }
 
-      assert_equal 1, homes.uniq.size
-      assert_equal File.join(cell.workspace, "0", "home"), homes.first
+      assert_equal 2, homes.uniq.size, "the second request was handed the first request's directory"
+      assert_equal [ File.join(cell.workspace, "0") ], homes.map { |home| File.dirname(home) }.uniq
     end
   end
 

--- a/hotcell-server/test/slot_test.rb
+++ b/hotcell-server/test/slot_test.rb
@@ -14,7 +14,29 @@ class SlotTest < HotCellServerTest
   end
 
   def teardown
+    restore_modes
     FileUtils.remove_entry @workspace if Dir.exist?(@workspace)
+  end
+
+  # adr/0003 says no file outlives its request, and `max_requests_per_worker: 1` is priced on that. A tool
+  # that reaches code execution runs as the user that owns the tree, so it can make its own configuration
+  # undeletable and lock the directory the next home would be created in. If the next request lands on the
+  # same path it reads that configuration, and ImageMagick's `delegates.xml` is a command line.
+  def test_a_home_a_tool_locked_open_is_never_handed_to_a_later_request
+    first = @slot.make_home
+    delegates = File.join(first, ".config", "ImageMagick", "delegates.xml")
+    FileUtils.mkdir_p File.dirname(delegates)
+    File.write delegates, "<delegatemap/>"
+    File.chmod 0o500, File.dirname(delegates)
+    File.chmod 0o500, File.dirname(first)
+
+    refute @slot.remove_home, "the locked tree should have refused to go"
+
+    second = @slot.make_home
+
+    refute_equal first, second, "the next request was handed the path the last one poisoned"
+    refute File.exist?(File.join(second, ".config", "ImageMagick", "delegates.xml")),
+           "the next request read configuration the last one wrote"
   end
 
   def test_a_rename_failure_leaves_the_tree_rather_than_deleting_it_inline
@@ -30,12 +52,12 @@ class SlotTest < HotCellServerTest
   end
 
   def test_a_discard_renames_the_tree_aside_for_a_later_sweep
-    @slot.make_home
-    File.write File.join(@slot.home, "leftover"), "x"
+    home = @slot.make_home
+    File.write File.join(home, "leftover"), "x"
 
     @slot.discard_home
 
-    refute Dir.exist?(@slot.home), "the directory should have been renamed away"
+    refute Dir.exist?(home), "the directory should have been renamed away"
     assert_equal 1, discarded_names.size, "the tree should be waiting under a discarded name"
 
     @slot.sweep
@@ -48,7 +70,7 @@ class SlotTest < HotCellServerTest
 
     name = discarded_names.first
 
-    assert_match(/\.discarded-#{Process.pid}-[0-9a-f]{16}\z/, name,
+    assert_match(/\Adiscarded-#{Process.pid}-[0-9a-f]{16}\z/, name,
                  "the discarded name should end in a random suffix a tool cannot pre-create")
   end
 
@@ -79,8 +101,16 @@ class SlotTest < HotCellServerTest
   end
 
   private
+    def restore_modes
+      Dir.glob(File.join(@workspace, "**/"), File::FNM_DOTMATCH).each do |path|
+        File.chmod 0o700, path
+      rescue SystemCallError
+        nil
+      end
+    end
+
     def discarded_names
-      Dir.glob("#{@slot.home}.discarded-*").map { |path| File.basename(path) }
+      Dir.glob(File.join(@slot.directory, "discarded-*")).map { |path| File.basename(path) }
     end
 
     def stub_remove_entry_to_fail

--- a/hotcell-server/test/slot_test.rb
+++ b/hotcell-server/test/slot_test.rb
@@ -28,15 +28,68 @@ class SlotTest < HotCellServerTest
     FileUtils.mkdir_p File.dirname(delegates)
     File.write delegates, "<delegatemap/>"
     File.chmod 0o500, File.dirname(delegates)
-    File.chmod 0o500, File.dirname(first)
+    File.chmod 0o500, @slot.directory
 
-    refute @slot.remove_home, "the locked tree should have refused to go"
-
+    @slot.remove_home
     second = @slot.make_home
 
     refute_equal first, second, "the next request was handed the path the last one poisoned"
     refute File.exist?(File.join(second, ".config", "ImageMagick", "delegates.xml")),
            "the next request read configuration the last one wrote"
+  end
+
+  # The name is the guarantee and the removal is what keeps the disk. A mode is the only thing a tool needs
+  # to make its own tree unremovable, and a mode on a tree this uid owns is ours to put back — so a failed
+  # removal is retried after repairing what the tool changed, rather than left to accumulate one tree per
+  # request until the tmpfs is full.
+  def test_a_tree_a_tool_made_unremovable_is_repaired_and_removed
+    home = @slot.make_home
+    locked = File.join(home, ".config")
+    FileUtils.mkdir_p locked
+    File.write File.join(locked, "delegates.xml"), "<delegatemap/>"
+    File.chmod 0o500, locked
+
+    assert @slot.remove_home, "the removal gave up on a mode it could have repaired"
+    refute Dir.exist?(home), "the tree is still on the tmpfs"
+  end
+
+  def test_a_discarded_tree_a_tool_made_unremovable_is_repaired_and_swept
+    home = @slot.make_home
+    locked = File.join(home, ".config")
+    FileUtils.mkdir_p locked
+    File.write File.join(locked, "delegates.xml"), "<delegatemap/>"
+    File.chmod 0o500, locked
+
+    assert @slot.discard_home
+    assert @slot.sweep, "the sweep gave up on a mode it could have repaired"
+    assert_empty discarded_names, "the discarded tree is still on the tmpfs"
+  end
+
+  # A home whose cleanup genuinely could not run is still never reused, because the name of the next one is
+  # not a name any earlier request has held.
+  def test_a_home_whose_cleanup_failed_is_never_handed_to_a_later_request
+    first = @slot.make_home
+    File.write File.join(first, "delegates.xml"), "<delegatemap/>"
+
+    stub_remove_entry_to_fail do
+      refute @slot.remove_home, "a removal that failed reported success"
+    end
+
+    second = @slot.make_home
+
+    refute_equal first, second
+    refute File.exist?(File.join(second, "delegates.xml"))
+  end
+
+  # `Dir.exist?` follows symlinks and answers false for a dangling one, so an entry a tool left in the slot's
+  # place survived the boot sweep and every later `make_home` raised on it.
+  def test_a_slot_directory_that_is_not_a_directory_is_cleared_at_boot
+    File.symlink File.join(@workspace, "nowhere"), @slot.directory
+
+    assert @slot.prepare, "the boot sweep reported success without clearing the entry"
+    refute File.symlink?(@slot.directory), "the entry a tool left in the slot's place is still there"
+
+    @slot.make_home
   end
 
   def test_a_rename_failure_leaves_the_tree_rather_than_deleting_it_inline

--- a/hotcell-server/test/worker_test.rb
+++ b/hotcell-server/test/worker_test.rb
@@ -28,6 +28,18 @@ class WorkerTest < HotCellServerTest
     assert_equal({ idle: true, code: "unavailable" }, report)
   end
 
+  # A home the worker cannot create is a broken deployment, not a verdict on the document — and a request
+  # that never ran must not be reported as one that succeeded. Creating it used to sit outside the begin, so
+  # the failure left the caller with no response while the supervisor was told idle `"ok"`.
+  def test_a_home_that_cannot_be_created_is_reported_failed
+    slot = @worker.send :slot
+    File.symlink File.join(slot.directory, "nowhere"), slot.directory
+
+    @worker.send :serve, HotCell::Connection.new(@client.last), 0
+
+    assert_equal({ idle: true, code: "failed" }, report)
+  end
+
   private
     def report
       raise "the worker never reported" unless @control.first.wait_readable(1)


### PR DESCRIPTION
`Slot#make_home` always used the stable path `workspace/<slot>/home`, and `FileUtils.mkdir_p(home, mode: 0700)` sets the mode only when it creates the directory. A tool that reached code execution could write `$HOME/.config/ImageMagick/delegates.xml`, `chmod 0500` that directory and the slot directory around it, and exit. The worker's recursive delete could not unlink the config entry, the same-uid supervisor could not rename `home` inside a non-writable parent, both cleanups answered false, both callers logged — and the slot went back into service under the same name. A distinct later worker was handed the tree that had just refused to go, and ImageMagick runs the command lines in `delegates.xml`.

That falsifies `docs/DESIGN.md` and [ADR 0003](adr/0003-remove-the-persistent-slot-home.md): no file outlives its request, and `max_requests_per_worker: 1` bounds a compromise.

Two commits, each with its reproducer kept as a regression:

**Name each request's home freshly.** A `Slot` now holds its numbered directory, and `make_home` creates `home-<random hex>` inside it. A name no earlier request has held is not a name an earlier request could have prepared, so a cleanup that fails costs disk rather than isolation. The slot directory's mode is reasserted first, because it is the one predictable name left and a mode on a directory this uid owns is ours to put back. `ENV["HOME"]` moves from once-at-fork to once-per-request. Because the name is assigned after the fork, the supervisor's copy of the slot never learns it, so `discard_home` renames what matches `home-*` and `prepare` clears the whole slot directory at boot.

**Repair the modes, then remove the tree.** A `chmod 0500` was enough to fail the delete underneath it, and one tree per request then stayed on the tmpfs, readable by every later request on the slot, until the container ended — while `sweep`'s failure was reported nowhere at all. A failed removal is now retried after putting the modes back, and `slot.unswept` says so when it still fails. Two smaller defects from the same review: `prepare` guarded on `Dir.exist?`, which follows symlinks and answers false for a dangling one, so the entry that most needs clearing survived boot and raised from every later `make_home`; and creating the home sat outside `Worker#serve`'s `begin`, so a failure skipped every response path after the ensure had already reported idle `"ok"` for a request that never ran.

`docs/DESIGN.md` § "Worker isolation" and the comments in `slot.rb` state the narrower property this actually buys. It closes the offline route, where nothing of the attacker's is still running. It does not bound a live one: workers share a uid and `0700` is the owner's own mode, so a concurrent sibling — or a `setsid` descendant of a finished request, which process groups do not contain — can still write into a home the moment it exists. Those are the residuals the same section already records, and their remedy is [#13](https://github.com/basecamp/hotcell/issues/13).

`CellTest#test_a_home_that_cannot_be_removed_is_reported` asserted that a mode-locked home produces `slot.uncleaned`. It no longer does, because the removal now succeeds, so the test asserts that instead. Cell-level coverage of the reporting path goes with it — a removal failure that repair cannot rescue needs `CAP_LINUX_IMMUTABLE`, which a cell does not have. The unit tests still drive the false return through a stub.

HC-PT-001 of the purple-team assessment of 2026-08-22. Its remaining remediation bullets are deliberately not here: slot poisoning and cell retirement on an unrepairable cleanup failure, and holding the slot directory on a side the worker cannot mutate, which is #23.
