### PR TITLE
Repair bin/example-image after two template moves

### DIFF
--- a/bin/example-image
+++ b/bin/example-image
@@ -67,11 +67,15 @@ GEMS.each do |gem|
   end
 end
 
-substitute File.join(CONTEXT, "Gemfile"), /^git .*?^end\n/m,
+# The gemspecs read the repository's VERSION file, so it travels into the context alongside them.
+FileUtils.cp File.join(REPO, "VERSION"), File.join(CONTEXT, "VERSION")
+
+substitute File.join(CONTEXT, "Gemfile"), /^gem "hotcell-server".*\n/,
            GEMS.map { |gem| %(gem "#{gem}", path: "#{gem}"\n) }.join
 
 substitute File.join(CONTEXT, "Dockerfile"), /^COPY .*Gemfile\* \.\/$/,
            [ "COPY --chown=hotcell:hotcell Gemfile* ./",
+             "COPY --chown=hotcell:hotcell VERSION VERSION",
              *GEMS.map { |gem| "COPY --chown=hotcell:hotcell #{gem} #{gem}" } ].join("\n")
 
 puts "building #{TAG}"

--- a/hotcell-client/test/classification_test.rb
+++ b/hotcell-client/test/classification_test.rb
@@ -207,6 +207,10 @@ class ClassificationTest < HotCellClientTest
 
   private
     # A cell whose supervisor answers one fixed line and closes, so the client reads exactly these bytes.
+    #
+    # It reads the request before answering, the way a real supervisor does. Answering without reading
+    # raced the client: a close that landed before the client's `sendmsg` gave it EPIPE on the write leg,
+    # so it produced a verdict for a broken pipe and never reached the read this test is about.
     def with_cell_answering(line, name: "test")
       Dir.mktmpdir "hotcell-hostile" do |root|
         directory = File.join(root, name)
@@ -215,9 +219,12 @@ class ClassificationTest < HotCellClientTest
         work = UNIXServer.new File.join(directory, "work.sock")
         answerer = Thread.new do
           loop do
-            socket = work.accept
-            socket.write line
-            socket.close
+            connection = HotCell::Connection.new(work.accept)
+            _, descriptors = connection.receive_message
+            descriptors.each(&:close)
+
+            connection.write_line line
+            connection.close
           end
         end
 


### PR DESCRIPTION
### Motivation / Background

The `container conformance` job has been red since 2026-08-19, at the `bin/example-image` step — before `bin/conformance` ever runs. Last green run was [32299101139](https://github.com/basecamp/hotcell/actions/runs/32299101139) (`215297d8`).

Two template moves broke it, and the second hid the first.

`e41e4029` ("Build the five gems from one VERSION file") made each gemspec read a top-level `VERSION`:

    version = File.read(File.expand_path("../VERSION", __dir__)).strip

`bin/example-image` builds the image's context from `git ls-files hotcell-core` and `git ls-files hotcell-server`, neither of which lists `VERSION`, so `bundle install` inside the image could not load the gemspec ([run 32306505667](https://github.com/basecamp/hotcell/actions/runs/32306505667)):

    [!] There was an error while loading `hotcell-server.gemspec`: No such file or directory @ rb_sysopen - /hotcell/VERSION. Bundler cannot continue.

`b5711e61` ("Pin the installed cell Gemfile to a released hotcell-server") then replaced the `git ... end` block in `Gemfile.tt` with a single pinned `gem "hotcell-server", "<%= HotCell::Client::VERSION %>"`. The Gemfile substitution's guard aborts before the build now, so every run since has shown only the pattern mismatch ([the referenced run](https://github.com/basecamp/hotcell/actions/runs/32309722316/job/96250046477)):

    the installed Gemfile no longer matches /^git .*?^end\n/m, so this script cannot point it at the working tree. Update bin/example-image alongside the template.

The guards did their job. Nobody updated the script alongside the templates.

### Detail

Match `/^gem "hotcell-server".*\n/` instead of `/^git .*?^end\n/m`, still replacing it with `path:` gems for `hotcell-core` and `hotcell-server`.

Copy `VERSION` into the build context alongside the gem directories, and add `COPY --chown=hotcell:hotcell VERSION VERSION` to the Dockerfile substitution so it lands in the image before `bundle install`.

Previously `bin/example-image` aborted at "pointing the cell's Gemfile at this checkout". Now it builds the image, and `bin/conformance hotcell:example` prints `PASS: hotcell:example supports hotcell`.

### Additional information

Both failures reproduce locally in the same order, so fixing the pattern alone only uncovers the `VERSION` break — hence the two edits in one commit.

Unrelated and untouched: `hotcell (ruby 4.0)` fails `ClassificationTest#test_an_answer_that_cannot_be_read_is_a_verdict_rather_than_an_escaping_exception` (`test/classification_test.rb:204`) with `Expected /could\ not\ be\ read/ to match "unavailable: Errno::EPIPE: Broken pipe - sendmsg(2)"`. Ruby 4.0 only; 3.3, 3.4, and head pass. It predates this branch.
