### PR TITLE
Create the scaffold's operations directory rather than ship it

### DIFF
--- a/hotcell-client/lib/hot_cell/install.rb
+++ b/hotcell-client/lib/hot_cell/install.rb
@@ -18,8 +18,12 @@ module HotCell
       def call(root, out: $stdout)
         templates.each do |template|
           relative = template.delete_prefix("#{TEMPLATES}/").delete_suffix(".tt")
-          install template, File.join(root, "hotcell", relative), "hotcell/#{relative}", out
+          write File.join(root, "hotcell", relative), "hotcell/#{relative}", out do
+            render template
+          end
         end
+
+        keep_operations root, out
       end
 
       private
@@ -27,12 +31,27 @@ module HotCell
           Dir.glob("#{TEMPLATES}/**/*.tt", File::FNM_DOTMATCH).sort
         end
 
-        def install(template, destination, label, out)
+        # **The directory the generated Dockerfile copies, made here rather than shipped.**
+        #
+        # It used to be a template, `install/operations/.keep.tt`, and a dotfile is exactly what the
+        # gemspec's `Dir["lib/**/*"]` does not match — so the published 0.1.0 carried the directory's only
+        # file nowhere, `COPY operations/` had nothing to copy, and the advertised scaffold could not build.
+        # The checkout's own install test could not see it, because in a checkout the file is simply there.
+        #
+        # An empty file rather than an empty directory, because the application's git is what has to keep
+        # this after a fresh clone, and git tracks no empty directories.
+        def keep_operations(root, out)
+          write File.join(root, "hotcell", "operations", ".keep"), "hotcell/operations/.keep", out do
+            ""
+          end
+        end
+
+        def write(destination, label, out)
           if File.exist?(destination)
             out.puts "   skip  #{label} (already exists)"
           else
             FileUtils.mkdir_p File.dirname(destination)
-            File.write destination, render(template)
+            File.write destination, yield
             out.puts " create  #{label}"
           end
         end

--- a/hotcell-client/test/install_test.rb
+++ b/hotcell-client/test/install_test.rb
@@ -27,6 +27,20 @@ class InstallTest < HotCellClientTest
     end
   end
 
+  # **`install_test` above runs from the checkout, where every template is present whether or not it was
+  # packaged.** That is what let the published 0.1.0 advertise a scaffold it could not build: the gemspec
+  # selects `Dir["lib/**/*"]`, which does not match a dotfile, so `install/operations/.keep.tt` was in the
+  # working tree and not in the gem, and the generated Dockerfile's `COPY operations/` had nothing to copy.
+  # This is the difference between the two lists.
+  def test_every_installer_template_is_packaged
+    root = File.expand_path("..", __dir__)
+    spec = Gem::Specification.load(File.join(root, "hotcell-client.gemspec"))
+    templates = Dir.glob("#{HotCell::Install::TEMPLATES}/**/*.tt", File::FNM_DOTMATCH)
+      .map { |path| path.delete_prefix("#{root}/") }
+
+    assert_empty templates - spec.files, "an installer template the published gem would not carry"
+  end
+
   # The Gemfile template is ERB rather than a copy, because the cell's server and this client are halves of
   # one wire contract: a skew between them answers `protocol` on every request.
   def test_install_pins_the_cell_to_the_installing_clients_version


### PR DESCRIPTION
`hotcell-client.gemspec` selects `Dir["lib/**/*"]`, which does not match a dotfile, so `lib/hot_cell/install/operations/.keep.tt` sat in the working tree and never entered the gem. The directory entry above it is in the list, but RubyGems packages files and not directories, so the published 0.1.0 carried no `operations/` at all. Its installer wrote `Dockerfile`, `Gemfile` and `config.rb`, while the Dockerfile it generates runs `COPY operations/` unconditionally — the advertised fresh scaffold could not build. `install_test.rb` passed throughout, because it runs from a checkout where the template is simply there.

Write `hotcell/operations/.keep` from the installer and drop the template. A file rather than a bare directory, because the application's own git is what has to keep it after a fresh clone. `Install.call` now ends by ensuring it, through the same create-or-skip path as every template, so running the installer twice is still safe.

Confirmed against built artifacts rather than the checkout, which is the part of this the existing test could not reach. Building each gem, unpacking it and running its installer:

```
master's gem   -> hotcell/{Dockerfile,Gemfile,config.rb}
this branch    -> hotcell/{Dockerfile,Gemfile,config.rb,operations/.keep}
```

`install_test.rb` gains a check that every installer template appears in the gemspec's file list, which is the test that would have caught this. The gemspec's glob is unchanged: with no dot templates left there is nothing for it to miss, and that check fails loudly the moment someone adds one, which is a better guard than a wider glob nobody rereads.

Two items from this finding's remediation are deliberately not here, so they are not lost:

- **Exercise the built gem in CI.** Install the `.gem` into an empty directory, assert `operations/` exists, and build the generated image. Everything above was verified by hand; nothing yet stops it regressing in a way only an artifact shows.
- **Move publishing to a tag-bound workflow.** The current release path is manual (`Rakefile`): it does not require a clean tree, prove the tag equals HEAD, sign or attest the artifact, retain checksums or an SBOM, or inspect the final manifest. Because gemspecs select from the working filesystem, an untracked file under an included path can enter a release. That is release engineering rather than a bug fix.

A patch release is wanted once this lands, since the published 0.1.0 is the broken artifact.

HC-PT-008 of the purple-team assessment of 2026-08-22.
