### PR TITLE
Read a cell's description inside a rescue

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -436,6 +436,20 @@ like every other boot check here.
   somewhere else, so nothing else would catch a cell image that moved its gid. A cell too old to report
   them says nothing.
 
+Neither check trusts what the cell says. The process answering runs untrusted content, so its description
+is read inside a rescue: an answer this client cannot use is logged and ignored, and the cell is treated as
+one that answered nothing. What that catches is a misdeployment, not a compromised cell — a cell that has been taken over can answer a perfectly well-formed
+description that is simply false, and nothing on this side can tell.
+
+What the rescue covers is what a cell *says*. It does not cover a cell that never answers at boot:
+`control_timeout` bounds the answer and not the connection, so a listener that stops accepting until its
+backlog fills can hold the connect. That is [#20](https://github.com/basecamp/hotcell/issues/20).
+
+And it covers what raises at boot, not what a value does later. A description is handed back whole, so a
+cell can put a string in it that is not valid UTF-8, or a number that parses to an infinity. Neither raises
+here. The whole returned description stays untrusted: validate it for whatever you do with it — serializing,
+matching, storing or rendering are all places these values raise.
+
 ## Making the numbers agree
 
 Nothing checks these three for you.

--- a/hotcell-client/lib/hot_cell/cell.rb
+++ b/hotcell-client/lib/hot_cell/cell.rb
@@ -71,19 +71,28 @@ module HotCell
     # Boot must not fail when a cell does not answer. A cell that is down at app boot is a degraded
     # deployment rather than a broken one, and an application that refuses to start because its thumbnail
     # cell is restarting is worse than one that serves placeholders. So this warns and carries on.
+    #
+    # Nor when a cell answers something this client cannot read. The three warnings below reach into the
+    # description without checking types, so a cell that sends the wrong ones raises here — and the README
+    # calls `describe_cells` from `after_initialize`, where that is not a failed check but an application
+    # that does not boot. The process that wrote the description is the one that runs untrusted content.
+    # So rescue: returning nil is what an unreachable cell already returns, and every caller handles it.
     def describe
       return nil unless enabled?
 
       response = control(DESCRIBE)
-      unless response.ok?
-        HotCell.logger.warn "hotcell #{name}: #{unreachable_because response.failure}"
-        return nil
-      end
+      return warn_unreachable(response.failure) unless response.ok?
 
-      warn_about_timeout response.result
-      warn_about_missing_operations response.result
-      warn_about_group_skew response.result
-      response.result
+      response.result.tap do |described|
+        warn_about_timeout described
+        warn_about_missing_operations described
+        warn_about_group_skew described
+      end
+    rescue StandardError => error
+      HotCell.logger.warn "hotcell #{name}: this cell's description could not be read and is being " \
+                          "ignored (#{error.class}: #{Failure.one_line error.message}). Boot continues; " \
+                          "nothing it carries is assumed."
+      nil
     end
 
     def metrics
@@ -95,13 +104,18 @@ module HotCell
       # that admits a caller. EACCES therefore means one thing, and it is worth saying rather than leaving an
       # operator to read "could not describe the cell" as "the cell is down". Every other failure reads that
       # way correctly, because a restarting accessory is the common one.
+      def warn_unreachable(failure)
+        HotCell.logger.warn "hotcell #{name}: #{unreachable_because failure}"
+        nil
+      end
+
       def unreachable_because(failure)
         if failure.error_class == "Errno::EACCES"
           "this process may not open the cell's socket. Both sides share a group, and this one is in " \
           "#{Process.groups.sort.inspect}. Add the cell's gid to this container (Kamal: `group-add` under " \
           "the role's `options:`)."
         else
-          "could not describe the cell (#{failure})"
+          "could not describe the cell (#{Failure.one_line failure})"
         end
       end
 
@@ -124,10 +138,9 @@ module HotCell
         return if needed.nil? || timeout.nil? || timeout >= needed
 
         HotCell.logger.warn "hotcell #{name}: this client waits #{seconds timeout} and the cell says it may " \
-                            "take #{seconds needed} to answer (queue_wait #{seconds described[:queue_wait]} + " \
-                            "deadline #{seconds described[:deadline]} + the time to kill and reply), so a " \
-                            "saturated cell will arrive here as a transport failure rather than as its own " \
-                            "verdict. Deliberate on a synchronous path; a mistake for a background job."
+                            "take #{seconds needed} to answer, so a saturated cell will arrive here as a " \
+                            "transport failure rather than as its own verdict. Deliberate on a synchronous " \
+                            "path; a mistake for a background job."
       end
 
       # The cell reports seconds as floats, and "41.0s" is a worse sentence than "41s".

--- a/hotcell-client/test/describe_survival_test.rb
+++ b/hotcell-client/test/describe_survival_test.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# `describe` is the one call a cell answers before the application is serving, and the README puts it in
+# `after_initialize`, where an exception is not a failed check but a Rails application that does not boot.
+# The process answering runs untrusted content, and `docs/DESIGN.md` records the socket theft that lets a
+# compromised worker be the thing that answers — so nothing it sends may raise out of `describe`.
+class DescribeSurvivalTest < HotCellClientTest
+  # Correctly framed responses whose contents this client cannot use. Each raised out of `describe` before
+  # the rescue was added.
+  UNUSABLE = [
+    %({"answer_within":"attacker-controlled"}),
+    %({"answer_within":{"not":"a number"}}),
+    %(["not","an","object"]),
+    %("a string"),
+    %(null),
+  ].freeze
+
+  # Legitimate, and the reason this is a rescue rather than a required shape: `describe` is additive, so a
+  # cell reports what it has and one too old to report a field must stay readable.
+  USABLE = [
+    %({}),
+    %({"answer_within":31}),
+    %({"answer_within":1.0,"groups":[],"operations":[]}),
+  ].freeze
+
+  def test_nothing_a_cell_answers_raises_out_of_describe
+    UNUSABLE.each do |result|
+      with_cell_describing(result, timeout: 30) do |cell|
+        assert_nil quietly { cell.describe }, "#{result} was believed"
+      end
+    end
+  end
+
+  def test_a_cell_that_reports_fewer_fields_is_still_read
+    USABLE.each do |result|
+      with_cell_describing(result, timeout: 30) do |cell|
+        refute_nil quietly { cell.describe }, "#{result} was discarded"
+      end
+    end
+  end
+
+  # `groups` is only read when this application has a group to compare it against, so a wrong type there
+  # raises for a configured application and not for a bare one. What breaks is the code that reads the
+  # field, not the shape of the response — which is why this is a rescue and not a check on the way in.
+  def test_a_wrong_type_is_ignored_where_the_consumer_reaches_it
+    with_cell_describing(%({"groups":5}), timeout: 30) do |cell|
+      HotCell.group = 1000
+
+      assert_nil quietly { cell.describe }, "a groups the consumer could not read was believed"
+    ensure
+      HotCell.group = nil
+    end
+  end
+
+  def test_an_ignored_description_says_why
+    with_cell_describing(%({"answer_within":"attacker-controlled"}), timeout: 30) do |cell|
+      warnings = capturing_warnings { cell.describe }
+
+      assert_match "could not be read and is being ignored", warnings
+      assert_match "ArgumentError", warnings
+    end
+  end
+
+  # Everything after the prefix on this line was chosen by the cell. `Failure.sanitize` bounds and scrubs
+  # it but leaves newlines alone, so an unescaped message is a second log line that nothing wrote.
+  def test_a_cell_cannot_forge_a_log_line
+    forged = %(ERROR -- : hotcell test: everything is fine)
+    failure = %({"code":"failed","message":"first line\\n#{forged}"})
+
+    with_cell_describing(nil, failure: failure) do |cell|
+      warnings = capturing_warnings { cell.describe }
+
+      assert_match "first line", warnings
+      assert_equal 1, warnings.lines.grep(/hotcell test/).size, "the cell wrote a line of its own: #{warnings}"
+      assert_match '\n', warnings
+    end
+  end
+
+  def test_one_unusable_cell_does_not_stop_the_others_being_read
+    Dir.mktmpdir "hc" do |root|
+      answering root, "hostile", %({"answer_within":"attacker-controlled"})
+      answering root, "honest", %({"answer_within":1.0,"groups":[],"operations":[]})
+
+      HotCell.root = root
+      %w[ hostile honest ].each do |name|
+        HotCell.register name, timeout: 30, control_timeout: 2, permanent: Unprocessable,
+                               transient: TemporarilyUnavailable
+      end
+
+      described = quietly { HotCell.describe_cells }
+
+      assert_nil described["hostile"], "the hostile cell was believed"
+      refute_nil described["honest"], "one bad peer stopped the others being read"
+    ensure
+      stop_answering
+    end
+  end
+
+  private
+    def quietly
+      HotCell.logger = Logger.new(File::NULL)
+      yield
+    end
+
+    def capturing_warnings
+      captured = StringIO.new
+      HotCell.logger = Logger.new(captured)
+      yield
+      captured.string
+    ensure
+      HotCell.logger = Logger.new(File::NULL)
+    end
+
+    def with_cell_describing(result, name: "test", failure: nil, **register)
+      Dir.mktmpdir "hc" do |root|
+        answering root, name, result, failure: failure
+        HotCell.root = root
+
+        yield HotCell.register(name, control_timeout: 2, permanent: Unprocessable,
+                                     transient: TemporarilyUnavailable, **register)
+      ensure
+        stop_answering
+      end
+    end
+
+    # One cell's control socket, answering the same line to whatever connects.
+    def answering(root, name, result, failure: nil)
+      directory = File.join(root, name)
+      Dir.mkdir directory
+
+      listener = UNIXServer.new File.join(directory, "control.sock")
+      line = if failure
+        %({"v":1,"ok":false,"error":#{failure},"timing":{}}\n)
+      else
+        %({"v":1,"ok":true,"result":#{result},"timing":{}}\n)
+      end
+
+      (@listeners ||= []) << listener
+      (@answerers ||= []) << Thread.new do
+        loop do
+          connection = listener.accept
+          connection.readpartial(4096)
+          connection.write line
+          connection.close
+        end
+      rescue IOError, Errno::EBADF
+        nil
+      end
+    end
+
+    def stop_answering
+      @answerers&.each(&:kill)
+      @listeners&.each(&:close)
+      @answerers = @listeners = nil
+    end
+end

--- a/hotcell-core/lib/hot_cell/failure.rb
+++ b/hotcell-core/lib/hot_cell/failure.rb
@@ -76,6 +76,14 @@ module HotCell
             error_class: wire[:class], message: wire[:message]
       end
 
+      # For a message that is about to be written as one line of a log. `sanitize` leaves CR and LF alone,
+      # which is right for a message an application stores or re-raises, but a peer that puts a newline in
+      # one writes a second log line of its own — formatted and indented like the real ones. Escape them,
+      # and the rest of the control characters with them.
+      def one_line(text)
+        sanitize(text)&.gsub(/[[:cntrl:]]/) { |character| character.dump[1..-2] }
+      end
+
       def sanitize(message)
         return nil if message.nil?
 


### PR DESCRIPTION
`Cell#describe` read a cell's JSON response without checking it — comparing `answer_within` numerically, calling `include?` on `groups`. A cell that answered the wrong types raised, and the README calls `describe_cells` from `after_initialize`, so the Rails application did not boot. The process answering is the one that runs untrusted content.

Read the description inside a rescue instead. One that cannot be read is logged and ignored, and `describe` returns `nil` — what an unreachable cell already returns and what every caller handles.

A rescue rather than a schema, because what breaks is the code that reads a field and not the shape of the response: `{"answer_within":31}` is valid and correctly typed, and it still raised, since the warning it triggers interpolated `queue_wait` and `deadline`, which a cell need not send. That warning no longer prints them.

Also here: `Failure.one_line`, which escapes control characters in a cell's bytes before they reach a log.

`docs/DEPLOYMENT.md` records the two things this does not cover — a cell that never answers (#20), and a value that raises later rather than at boot.

HC-PT-005 of the purple-team assessment of 2026-08-22.
