### PR TITLE
Correct the converter dependency floors so a floor resolution can boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,32 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake test:activestorage
 
+  # The same conversions, resolved at the gemspec's declared dependency floors rather than at the newest gems.
+  # The default lane above always runs the latest mini_magick and ruby-vips, so it cannot catch a floor that
+  # names a version without the API the operations call at boot. This lane boots and converts against
+  # gemfiles/minimum.gemfile, so the floors we ship are the floors we test. One Ruby: the floors are gem
+  # versions, independent of the interpreter.
+  activestorage-minimum:
+    name: "activestorage (minimum dependencies)"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      BUNDLE_GEMFILE: gemfiles/minimum.gemfile
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install the converters
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install --no-install-recommends -y libvips42 mupdf-tools poppler-utils ffmpeg imagemagick
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - run: bundle exec rake test:activestorage
+
   # The container and isolation path, covered for real. bin/example-image runs the installer and builds
   # what it wrote, so the scaffold an application actually gets is what is under test; bin/conformance then
   # drives the example battery through it from a second container, checking the descriptor crossing the

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 Gemfile.lock
 */pkg/
 *.gem
+gemfiles/*.lock

--- a/activestorage-hotcell-server/activestorage-hotcell-server.gemspec
+++ b/activestorage-hotcell-server/activestorage-hotcell-server.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "hotcell-server", version
   spec.add_dependency "image_processing", ">= 2.0"
-  spec.add_dependency "mini_magick", ">= 4.0"
-  spec.add_dependency "ruby-vips", ">= 2.2"
+  spec.add_dependency "mini_magick", ">= 5.2.0"
+  spec.add_dependency "ruby-vips", ">= 2.2.1"
 end

--- a/activestorage-hotcell-server/test/dependency_floors_test.rb
+++ b/activestorage-hotcell-server/test/dependency_floors_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The gemspec declares the versions an installer is allowed to resolve, and the operations call methods only
+# some of those versions carry. magick_operation.rb sets `MiniMagick.restricted_env=`, added in mini_magick
+# 5.2.0; vips_operation.rb's before_fork guard requires `Vips.block_untrusted`, added in ruby-vips 2.2.1. A
+# floor below either lets an installer satisfy this gemspec and then die at boot — `NoMethodError` on the
+# magick side, a fail-closed `ConfigurationError` on the vips side — with the whole conversion toolchain
+# offline.
+#
+# This is the fast, syntactic half of the guard: it reads the declared requirement rather than resolving and
+# booting against it, so it runs in every suite with nothing installed. The `activestorage-minimum` CI lane is
+# the behavioural half — it installs these floors and runs the real conversions, so a converter method adopted
+# from a still-newer version is caught even before the constants below are updated to name it.
+class DependencyFloorsTest < ActiveStorageHotCellTest
+  GEMSPEC = Gem::Specification.load File.expand_path("../activestorage-hotcell-server.gemspec", __dir__)
+
+  # 5.1.2 and 4.13.2 lack `restricted_env=`; magick_operation.rb calls it at require time.
+  def test_mini_magick_floor_provides_restricted_env
+    assert_floor_excludes "mini_magick", "5.1.2"
+    assert_floor_admits   "mini_magick", "5.2.0"
+  end
+
+  # 2.2.0 lacks `Vips.block_untrusted`; vips_operation.rb's before_fork guard refuses to boot without it.
+  def test_ruby_vips_floor_provides_block_untrusted
+    assert_floor_excludes "ruby-vips", "2.2.0"
+    assert_floor_admits   "ruby-vips", "2.2.1"
+  end
+
+  private
+    def requirement_for(gem_name)
+      dependency = GEMSPEC.dependencies.find { |candidate| candidate.name == gem_name }
+      assert dependency, "#{gem_name} is not a declared dependency of the gemspec"
+      dependency.requirement
+    end
+
+    def assert_floor_excludes(gem_name, version)
+      refute requirement_for(gem_name).satisfied_by?(Gem::Version.new(version)),
+             "#{gem_name} floor must exclude #{version}, which lacks the API the operations call at boot"
+    end
+
+    def assert_floor_admits(gem_name, version)
+      assert requirement_for(gem_name).satisfied_by?(Gem::Version.new(version)),
+             "#{gem_name} floor must admit #{version}, the version that introduced the API"
+    end
+end

--- a/activestorage-hotcell-server/test/dependency_floors_test.rb
+++ b/activestorage-hotcell-server/test/dependency_floors_test.rb
@@ -16,16 +16,16 @@ require "test_helper"
 class DependencyFloorsTest < ActiveStorageHotCellTest
   GEMSPEC = Gem::Specification.load File.expand_path("../activestorage-hotcell-server.gemspec", __dir__)
 
-  # 5.1.2 and 4.13.2 lack `restricted_env=`; magick_operation.rb calls it at require time.
+  # `restricted_env=` arrived in mini_magick 5.2.0 — 5.1.2 and 4.13.2 lack it — and magick_operation.rb calls
+  # it at require time.
   def test_mini_magick_floor_provides_restricted_env
-    assert_floor_excludes "mini_magick", "5.1.2"
-    assert_floor_admits   "mini_magick", "5.2.0"
+    assert_effective_floor "mini_magick", "5.2.0"
   end
 
-  # 2.2.0 lacks `Vips.block_untrusted`; vips_operation.rb's before_fork guard refuses to boot without it.
+  # `Vips.block_untrusted` arrived in ruby-vips 2.2.1 — 2.2.0 lacks it — and vips_operation.rb's before_fork
+  # guard refuses to boot without it.
   def test_ruby_vips_floor_provides_block_untrusted
-    assert_floor_excludes "ruby-vips", "2.2.0"
-    assert_floor_admits   "ruby-vips", "2.2.1"
+    assert_effective_floor "ruby-vips", "2.2.1"
   end
 
   private
@@ -35,13 +35,16 @@ class DependencyFloorsTest < ActiveStorageHotCellTest
       dependency.requirement
     end
 
-    def assert_floor_excludes(gem_name, version)
-      refute requirement_for(gem_name).satisfied_by?(Gem::Version.new(version)),
-             "#{gem_name} floor must exclude #{version}, which lacks the API the operations call at boot"
-    end
+    # The declared requirement's effective lower bound must be at least `floor`, whatever form it takes —
+    # asserting the bound rather than a couple of point versions, so a later `>= 4.0, != 5.1.2` cannot slip a
+    # broken release back in below it. `"#{floor}.a"` is the highest prerelease that still sorts below `floor`,
+    # so a requirement admits it exactly when its lower bound is looser than `floor`.
+    def assert_effective_floor(gem_name, floor)
+      requirement = requirement_for(gem_name)
 
-    def assert_floor_admits(gem_name, version)
-      assert requirement_for(gem_name).satisfied_by?(Gem::Version.new(version)),
-             "#{gem_name} floor must admit #{version}, the version that introduced the API"
+      assert requirement.satisfied_by?(Gem::Version.new(floor)),
+             "#{gem_name} floor must admit #{floor}, the version that introduced the API the operations call"
+      refute requirement.satisfied_by?(Gem::Version.new("#{floor}.a")),
+             "#{gem_name} floor must admit nothing below #{floor}, which lacks that API at boot"
     end
 end

--- a/activestorage-hotcell-server/test/dependency_floors_test.rb
+++ b/activestorage-hotcell-server/test/dependency_floors_test.rb
@@ -35,16 +35,21 @@ class DependencyFloorsTest < ActiveStorageHotCellTest
       dependency.requirement
     end
 
-    # The declared requirement's effective lower bound must be at least `floor`, whatever form it takes —
-    # asserting the bound rather than a couple of point versions, so a later `>= 4.0, != 5.1.2` cannot slip a
-    # broken release back in below it. `"#{floor}.a"` is the highest prerelease that still sorts below `floor`,
-    # so a requirement admits it exactly when its lower bound is looser than `floor`.
-    def assert_effective_floor(gem_name, floor)
-      requirement = requirement_for(gem_name)
+    # The declared requirement's effective lower bound must be at least `floor`, whatever form the requirement
+    # takes — asserting the bound structurally rather than probing point versions, so neither a later
+    # `>= 4.0, != 5.1.2` nor a `>= 5.2.0.rc1` can slip a release lacking the API back in below it. An upper
+    # bound (`< 6`) is fine; only the lower-bound clauses decide the floor, and their tightest is the smallest
+    # version the requirement admits.
+    LOWER_BOUND_OPERATORS = %w[ >= > = ~> ].freeze
 
-      assert requirement.satisfied_by?(Gem::Version.new(floor)),
-             "#{gem_name} floor must admit #{floor}, the version that introduced the API the operations call"
-      refute requirement.satisfied_by?(Gem::Version.new("#{floor}.a")),
-             "#{gem_name} floor must admit nothing below #{floor}, which lacks that API at boot"
+    def assert_effective_floor(gem_name, floor)
+      lower_bounds = requirement_for(gem_name).requirements
+        .select { |operator, _version| LOWER_BOUND_OPERATORS.include?(operator) }
+        .map { |_operator, version| version }
+
+      assert_predicate lower_bounds, :any?, "#{gem_name} declares no lower bound; it must floor at #{floor}"
+      assert_operator lower_bounds.max, :>=, Gem::Version.new(floor),
+                      "#{gem_name} floor must be at least #{floor}, the version that introduced the API the " \
+                      "operations call at boot"
     end
 end

--- a/gemfiles/minimum.gemfile
+++ b/gemfiles/minimum.gemfile
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Resolve the converter dependencies at the floors activestorage-hotcell-server.gemspec declares, rather than
+# at whatever is newest. The `activestorage-minimum` CI lane installs this and runs the real conversion suite,
+# so the floors we ship are the floors we test.
+#
+# The operations call `MiniMagick.restricted_env=` (mini_magick 5.2.0) and `Vips.block_untrusted` (ruby-vips
+# 2.2.1). A gemspec floor below either is a resolution that satisfies our own gemspec and then dies at boot,
+# with the whole toolchain offline. The default `activestorage` lane, on the newest gems, cannot see that —
+# this lane is what does. Each pin is the gemspec's own floor; raise it here in lockstep when a floor moves.
+eval_gemfile File.expand_path("../Gemfile", __dir__)
+
+gem "image_processing", "2.0.0"
+gem "mini_magick", "5.2.0"
+gem "ruby-vips", "2.2.1"


### PR DESCRIPTION
## Problem

`activestorage-hotcell-server.gemspec` declared floors that the code cannot actually run against:

```
mini_magick >= 4.0
ruby-vips   >= 2.2
```

But the operations call methods that only newer versions carry:

- `magick_operation.rb` sets `MiniMagick.restricted_env=` (and `MiniMagick.cli_env=`) at **require time**. `restricted_env=` was added in **mini_magick 5.2.0** — it is absent in 5.1.2 and 4.13.2.
- `vips_operation.rb`'s `before_fork` guard requires `Vips.block_untrusted`, added in **ruby-vips 2.2.1** — absent in 2.2.0. The guard fails closed with `ConfigurationError`.

A bundle that satisfied the declared floors could resolve `mini_magick` 5.1.2 (or 4.13.2) and `ruby-vips` 2.2.0 and then fail to boot the cell — `NoMethodError` on the magick side, a fail-closed `ConfigurationError` on the vips side — taking the whole conversion toolchain offline. This is availability/hardening-correctness rather than an isolation weakness: the two methods are hardening controls, and the boot fails closed. The declared floors are simply wrong.

Verified against the published gem sources: `MiniMagick.restricted_env=` first appears in mini_magick 5.2.0's `configuration.rb`; `Vips.block_untrusted` first appears in ruby-vips 2.2.1's `vips.rb`.

## Fix

Raise the floors to the versions that introduce the APIs the code depends on:

```
mini_magick >= 5.2.0
ruby-vips   >= 2.2.1
```

## Guards against recurrence

Two halves, so the floors and the code cannot silently drift apart again:

- **`dependency_floors_test.rb`** (syntactic, fast, no toolchain): asserts each declared floor *excludes* the versions that lack the required API and *admits* the version that introduced it. Fails before this change, passes after.
- **`gemfiles/minimum.gemfile` + a new `activestorage-minimum` CI lane** (behavioural): pins the converters to their declared floors and boots-and-converts the real suite against them. The default `activestorage` lane always resolves the newest gems, so it could never have caught this — the minimum lane is what tests the floors we ship.

## Verification

- New floors test fails on the old floors (both cases), passes on the new floors.
- `rake test:gem:activestorage-hotcell-server` green at the newest gems and at the pinned floors (mini_magick 5.2.0 / ruby-vips 2.2.1 / image_processing 2.0.0), 81 runs / 459 assertions.
- `gemfiles/minimum.gemfile` resolves to exactly the floor versions.
- `rubocop` clean on the changed files; `actionlint` clean on the workflow.
- No lockfile committed (`gemfiles/*.lock` is gitignored).
