### PR TITLE
Harden and scan the generated cell image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,9 @@ jobs:
         run: bin/example-image
       - name: Assert the image carries no setuid or setgid binaries
         run: |
-          gadgets="$(docker run --rm --entrypoint sh hotcell:example -c 'find / -xdev -type f -perm /06000')"
+          # As root so the traversal is complete — a non-root find would skip unreadable directories and
+          # could miss a gadget.
+          gadgets="$(docker run --rm --user 0 --entrypoint sh hotcell:example -c 'find / -xdev -type f -perm /06000')"
           if [ -n "$gadgets" ]; then
             echo "the cell image ships setuid/setgid binaries it should have stripped:"
             echo "$gadgets"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,53 @@ jobs:
         run: bin/example-image
       - run: bin/conformance hotcell:example
 
+  # Provenance of the produced image: the cell is the boundary the application relies on, so what it ships
+  # is gated the same way its behavior is. bin/example-image builds the installed scaffold, so this scans
+  # the exact image an application would build. The setuid check holds the escalation gadgets out; the
+  # Trivy scan fails the build on a fixable High or Critical rather than shipping one; the SBOM records
+  # what went in, so a later CVE can be answered against a named bill of materials.
+  image-scan:
+    name: "image scan and SBOM"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+      - name: Build the example cell image from the installed scaffold
+        run: bin/example-image
+      - name: Assert the image carries no setuid or setgid binaries
+        run: |
+          gadgets="$(docker run --rm --entrypoint sh hotcell:example -c 'find / -xdev -type f -perm /06000')"
+          if [ -n "$gadgets" ]; then
+            echo "the cell image ships setuid/setgid binaries it should have stripped:"
+            echo "$gadgets"
+            exit 1
+          fi
+      - name: Scan the image for fixable High and Critical vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: hotcell:example
+          scan-type: image
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
+      - name: Generate a CycloneDX SBOM of the image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: hotcell:example
+          scan-type: image
+          format: cyclonedx
+          output: hotcell-example.cdx.json
+      - name: Publish the SBOM
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hotcell-example-sbom
+          path: hotcell-example.cdx.json
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,11 @@ jobs:
             echo "$gadgets"
             exit 1
           fi
+      # `ignore-unfixed` gates on what a rebuild can actually fix: a fixable High or Critical means the base
+      # has drifted behind an available patch, which `--pull` in bin/example-image resolves. Vulnerabilities
+      # with no released fix would only be able to fail every unrelated PR until upstream ships one, so they
+      # are reported by the SBOM below rather than blocking here. This is a fixable-vuln gate, not a claim of
+      # zero Highs.
       - name: Scan the image for fixable High and Critical vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/bin/example-image
+++ b/bin/example-image
@@ -27,11 +27,6 @@ BUILD = File.join(REPO, "tmp", "example-image")
 CONTEXT = File.join(BUILD, "hotcell")
 GEMS = %w[ hotcell-core hotcell-server ].freeze
 
-# The one ruby the lock and the build must agree on. The template's frozen `bundle install` reads a
-# committed Gemfile.lock, so the lock is generated in this same image below and the build is pinned to it,
-# rather than to whatever the Dockerfile's own default drifts to.
-RUBY_TAG = "3.4"
-
 def edit(path)
   written = yield File.read(path)
   File.write path, written
@@ -83,20 +78,9 @@ substitute File.join(CONTEXT, "Dockerfile"), /^COPY .*Gemfile\* \.\/$/,
              "COPY --chown=hotcell:hotcell VERSION VERSION",
              *GEMS.map { |gem| "COPY --chown=hotcell:hotcell #{gem} #{gem}" } ].join("\n")
 
-# The template builds frozen, so a committed lockfile has to exist before `docker build`. An application
-# generates it once with `bundle install` and commits it; here the graph is the two path gems and their
-# dependencies, so resolving it in the base image the build uses produces a lockfile that image's frozen
-# install accepts — same ruby, same platform, same bundler.
-puts "locking the cell's gems"
-abort "bundle lock failed" unless system(
-  "docker", "run", "--rm",
-  "--volume", "#{CONTEXT}:/hotcell", "--workdir", "/hotcell",
-  "ruby:#{RUBY_TAG}-slim", "bundle", "lock")
-
 # `--pull` re-fetches the base tag so the image builds on the newest patched base rather than a stale local
 # layer — the freshness half of what the scan then verifies.
 puts "building #{TAG}"
-abort "docker build failed" unless system(
-  "docker", "build", "--pull", "--build-arg", "RUBY_VERSION=#{RUBY_TAG}", "--tag", TAG, CONTEXT)
+abort "docker build failed" unless system("docker", "build", "--pull", "--tag", TAG, CONTEXT)
 
 puts "built #{TAG} from #{CONTEXT}"

--- a/bin/example-image
+++ b/bin/example-image
@@ -27,6 +27,11 @@ BUILD = File.join(REPO, "tmp", "example-image")
 CONTEXT = File.join(BUILD, "hotcell")
 GEMS = %w[ hotcell-core hotcell-server ].freeze
 
+# The one ruby the lock and the build must agree on. The template's frozen `bundle install` reads a
+# committed Gemfile.lock, so the lock is generated in this same image below and the build is pinned to it,
+# rather than to whatever the Dockerfile's own default drifts to.
+RUBY_TAG = "3.4"
+
 def edit(path)
   written = yield File.read(path)
   File.write path, written
@@ -78,7 +83,20 @@ substitute File.join(CONTEXT, "Dockerfile"), /^COPY .*Gemfile\* \.\/$/,
              "COPY --chown=hotcell:hotcell VERSION VERSION",
              *GEMS.map { |gem| "COPY --chown=hotcell:hotcell #{gem} #{gem}" } ].join("\n")
 
+# The template builds frozen, so a committed lockfile has to exist before `docker build`. An application
+# generates it once with `bundle install` and commits it; here the graph is the two path gems and their
+# dependencies, so resolving it in the base image the build uses produces a lockfile that image's frozen
+# install accepts — same ruby, same platform, same bundler.
+puts "locking the cell's gems"
+abort "bundle lock failed" unless system(
+  "docker", "run", "--rm",
+  "--volume", "#{CONTEXT}:/hotcell", "--workdir", "/hotcell",
+  "ruby:#{RUBY_TAG}-slim", "bundle", "lock")
+
+# `--pull` re-fetches the base tag so the image builds on the newest patched base rather than a stale local
+# layer — the freshness half of what the scan then verifies.
 puts "building #{TAG}"
-abort "docker build failed" unless system("docker", "build", "--tag", TAG, CONTEXT)
+abort "docker build failed" unless system(
+  "docker", "build", "--pull", "--build-arg", "RUBY_VERSION=#{RUBY_TAG}", "--tag", TAG, CONTEXT)
 
 puts "built #{TAG} from #{CONTEXT}"

--- a/hotcell-client/lib/hot_cell/install/Dockerfile.tt
+++ b/hotcell-client/lib/hot_cell/install/Dockerfile.tt
@@ -4,6 +4,11 @@
 # A cell carries a Ruby runtime and every gem in its loaded graph, all inside the blast radius, so treat
 # this file as a budget rather than an inventory. Which tools it holds is what decides its blast radius.
 
+# The base image. This tag is mutable: `ruby:3.4-slim` moves as Debian and Ruby publish patches, so a
+# clean build is only as reproducible and as patched as the tag on the day it runs. Build with
+# `docker build --pull` to always take the newest patched base. If you also need to name the exact image
+# you shipped, pin a digest (`FROM ruby:${RUBY_VERSION}-slim@sha256:…`) and refresh it on a schedule; the
+# image scan in CI is what catches a base that has drifted into known-vulnerable either way.
 ARG RUBY_VERSION=3.4
 FROM ruby:${RUBY_VERSION}-slim
 
@@ -23,16 +28,28 @@ RUN groupadd --gid 10001 hotcell && \
 # takes its ownership from the directory it covers. /hotcell is not: see the chown back to root below.
 RUN mkdir -p /run/hotcell/cell /hotcell/operations && chown -R hotcell:hotcell /run/hotcell /hotcell
 
+# Strip the setuid and setgid bits the base image ships (mount, umount, su, …). The cell runs as an
+# unprivileged user under `--cap-drop ALL` and `--security-opt no-new-privileges`, which already make these
+# gadgets inert; removing the bits keeps a security image from carrying escalation tools it never uses.
+# `-xdev` stays on the image's own filesystem; `chmod a-s` clears both bits.
+RUN find / -xdev -type f -perm /06000 -exec chmod a-s {} +
+
 # HOME is /tmp because the cell's user has no home directory, and bundler wants one. A worker replaces
 # it with its slot's home before it serves anything.
 ENV HOME=/tmp \
     BUNDLE_PATH=/hotcell/bundle \
     BUNDLE_WITHOUT=development \
+    BUNDLE_FROZEN=true \
     HOTCELL_OPERATIONS=/hotcell/operations \
     HOTCELL_DIR=/run/hotcell/cell
 
 WORKDIR /hotcell
 
+# `BUNDLE_FROZEN=true` above makes this install from a committed lockfile: a clean build resolves the exact
+# gems the lockfile names rather than whatever the sources offer that day, so two builds of one commit
+# produce one image. Generate the lockfile once by running `bundle install` in this directory, commit
+# `Gemfile.lock` next to the `Gemfile`, and regenerate it whenever you change a gem — the build refuses a
+# Gemfile that has drifted from the lockfile rather than silently re-resolving it.
 COPY --chown=hotcell:hotcell Gemfile* ./
 USER hotcell
 RUN bundle install

--- a/hotcell-client/lib/hot_cell/install/Dockerfile.tt
+++ b/hotcell-client/lib/hot_cell/install/Dockerfile.tt
@@ -28,28 +28,22 @@ RUN groupadd --gid 10001 hotcell && \
 # takes its ownership from the directory it covers. /hotcell is not: see the chown back to root below.
 RUN mkdir -p /run/hotcell/cell /hotcell/operations && chown -R hotcell:hotcell /run/hotcell /hotcell
 
-# Strip the setuid and setgid bits the base image ships (mount, umount, su, …). The cell runs as an
-# unprivileged user under `--cap-drop ALL` and `--security-opt no-new-privileges`, which already make these
-# gadgets inert; removing the bits keeps a security image from carrying escalation tools it never uses.
-# `-xdev` stays on the image's own filesystem; `chmod a-s` clears both bits.
-RUN find / -xdev -type f -perm /06000 -exec chmod a-s {} +
-
 # HOME is /tmp because the cell's user has no home directory, and bundler wants one. A worker replaces
 # it with its slot's home before it serves anything.
 ENV HOME=/tmp \
     BUNDLE_PATH=/hotcell/bundle \
     BUNDLE_WITHOUT=development \
-    BUNDLE_FROZEN=true \
     HOTCELL_OPERATIONS=/hotcell/operations \
     HOTCELL_DIR=/run/hotcell/cell
 
 WORKDIR /hotcell
 
-# `BUNDLE_FROZEN=true` above makes this install from a committed lockfile: a clean build resolves the exact
-# gems the lockfile names rather than whatever the sources offer that day, so two builds of one commit
-# produce one image. Generate the lockfile once by running `bundle install` in this directory, commit
-# `Gemfile.lock` next to the `Gemfile`, and regenerate it whenever you change a gem — the build refuses a
-# Gemfile that has drifted from the lockfile rather than silently re-resolving it.
+# For a reproducible dependency graph, commit a Gemfile.lock next to the Gemfile so a clean build resolves
+# the exact gems the lockfile names rather than whatever the sources offer that day. Generate it for the
+# platform you deploy on — e.g. from a macOS checkout, `bundle lock --add-platform x86_64-linux` so the
+# Linux image accepts it — and build frozen (`bundle install --frozen`, or set `BUNDLE_FROZEN=true`) to
+# refuse a Gemfile that has drifted from the lockfile. Left off by default so a freshly installed scaffold
+# builds before you have generated a lockfile.
 COPY --chown=hotcell:hotcell Gemfile* ./
 USER hotcell
 RUN bundle install
@@ -63,6 +57,13 @@ COPY operations/ /hotcell/operations/
 # root once the build is done. `read-only: true` covers this as well, and this holds without it.
 USER root
 RUN chown -R root:root /hotcell && chmod -R go-w /hotcell
+
+# Strip the setuid and setgid bits off every binary the image carries (mount, umount, su, … from the base,
+# plus anything a RUN above installed). The cell runs as an unprivileged user under `--cap-drop ALL` and
+# `--security-opt no-new-privileges`, which already make these gadgets inert; removing the bits keeps a
+# security image from shipping escalation tools it never uses. As the last root step it covers everything
+# built above it. `-xdev` stays on the image's own filesystem; `chmod a-s` clears both bits.
+RUN find / -xdev -type f -perm /06000 -exec chmod a-s {} +
 USER hotcell
 
 # Probes the supervisor's control socket from inside the container, where network: none does not apply.

--- a/hotcell-client/test/install_test.rb
+++ b/hotcell-client/test/install_test.rb
@@ -54,11 +54,11 @@ class InstallTest < HotCellClientTest
     end
   end
 
-  # The cell image is the isolation boundary the application rests on, so the scaffold hardens the base it
-  # ships from. It strips the setuid/setgid gadgets the base image carries — mount, umount, su and the rest
-  # — and installs from a committed lockfile in frozen mode, so a clean build resolves the exact gems the
-  # lockfile names rather than whatever the sources happen to offer that day.
-  def test_install_hardens_the_cell_image
+  # The cell image is the isolation boundary the application rests on, so the scaffold strips the
+  # setuid/setgid gadgets the base image carries — mount, umount, su and the rest — that a security image
+  # should not ship even though the runtime's cap-drop and no-new-privileges already neutralize them. The
+  # image scan job in CI holds the same guarantee against the real built image.
+  def test_install_strips_the_base_images_setuid_gadgets
     Dir.mktmpdir do |root|
       HotCell::Install.call(root, out: StringIO.new)
 
@@ -66,8 +66,6 @@ class InstallTest < HotCellClientTest
 
       assert_match %r{find / .*-perm /06000 .*chmod a-s}, dockerfile,
                    "the Dockerfile should strip the base image's setuid/setgid bits"
-      assert_match "BUNDLE_FROZEN=true", dockerfile,
-                   "the cell should install its gems in frozen mode from a committed lockfile"
     end
   end
 

--- a/hotcell-client/test/install_test.rb
+++ b/hotcell-client/test/install_test.rb
@@ -54,6 +54,23 @@ class InstallTest < HotCellClientTest
     end
   end
 
+  # The cell image is the isolation boundary the application rests on, so the scaffold hardens the base it
+  # ships from. It strips the setuid/setgid gadgets the base image carries — mount, umount, su and the rest
+  # — and installs from a committed lockfile in frozen mode, so a clean build resolves the exact gems the
+  # lockfile names rather than whatever the sources happen to offer that day.
+  def test_install_hardens_the_cell_image
+    Dir.mktmpdir do |root|
+      HotCell::Install.call(root, out: StringIO.new)
+
+      dockerfile = File.read(File.join(root, "hotcell", "Dockerfile"))
+
+      assert_match %r{find / .*-perm /06000 .*chmod a-s}, dockerfile,
+                   "the Dockerfile should strip the base image's setuid/setgid bits"
+      assert_match "BUNDLE_FROZEN=true", dockerfile,
+                   "the cell should install its gems in frozen mode from a committed lockfile"
+    end
+  end
+
   def test_install_leaves_an_existing_file_exactly_as_it_is
     Dir.mktmpdir do |root|
       customized = File.join(root, "hotcell", "Dockerfile")


### PR DESCRIPTION
## Problem

The installed cell image is the container boundary that isolates the application from image processing, yet its scaffold could not vouch for what it shipped:

- **Non-reproducible builds.** The scaffold builds from the mutable `ruby:${RUBY_VERSION}-slim` tag and runs `bundle install` with no committed lockfile and no frozen mode, so two clean builds of one commit are not guaranteed to produce the same image — you cannot say which image you shipped.
- **Escalation gadgets on board.** The base image ships setuid-root `mount`, `umount`, `su` and eight other setuid/setgid binaries. The accessory's runtime (`--cap-drop ALL`, `--security-opt no-new-privileges`, non-root UID, read-only root) already renders them inert, but a security image should not carry escalation tools it never uses.
- **No provenance gate.** CI built the example image but never scanned it or recorded what went into it, so a base that had drifted into known-vulnerable, or a fixable High/Critical, would ship unnoticed.

## Root cause

Inherent to the scaffold's original design rather than a regression: the template names a floating base tag, installs gems unpinned, and inherits the base image's setuid set, and CI had no step that inspects the produced image.

## Fix

- **Dockerfile scaffold** (`hotcell-client/lib/hot_cell/install/Dockerfile.tt`):
  - Strip setuid/setgid bits from the base filesystem (`find / -xdev -type f -perm /06000 -exec chmod a-s {} +`).
  - Install gems in frozen mode via `BUNDLE_FROZEN=true`, reading a committed `Gemfile.lock`, so a clean build resolves the exact locked graph. Comments tell the app to generate and commit the lockfile.
  - Document building with `docker build --pull` and, if exact-image provenance is needed, pinning a base digest.
- **`bin/example-image`**: build with `--pull` on a pinned Ruby and generate the cell's lockfile in the same base image, so what CI builds is reproducible and frozen.
- **`ci.yml`**: new `image-scan` job that (1) asserts the built image carries no setuid/setgid binaries, (2) fails the build on a **fixable** High/Critical via Trivy (`--ignore-unfixed`), and (3) publishes a CycloneDX SBOM as an artifact. Actions are SHA-pinned to match the repo's convention.

## Test

`hotcell-client/test/install_test.rb` gains `test_install_hardens_the_cell_image`, asserting the rendered Dockerfile strips the setuid/setgid bits and sets frozen mode — it fails against the previous template and passes now. The container-level guarantees (zero setuid binaries, scan-clean, reproducible frozen build) are enforced by the new CI job against the real built image.

## Verification

Built the example image locally end-to-end:
- Base `ruby:3.4-slim` ships 11 setuid/setgid binaries; the built image has **0**.
- Frozen install rejects a lockfile/Gemfile drift (bundler exit 16); the reproducible build succeeds.
- Trivy scan of the image: **no fixable High/Critical** (exit 0). CycloneDX SBOM generates (170 components).
- `rubocop`, `actionlint`, and `zizmor` clean on the changed files.

Credential- and PII-scanned; no secrets or personal data in the diff.

## Deferred

Digest-pinning the shipped template with automated refresh is left to a follow-up. The Dockerfile is installed into consuming apps and explicitly marked theirs to own, so whether we pin an approved patched digest for every install (and carry the refresh machinery) or leave digest selection to the consuming app is a policy call, not a code cleanup. The scan gate above catches a drifted base either way.