### PR TITLE
Make the conformance gate verify the container flags it claims

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,10 @@ jobs:
   # The container and isolation path, covered for real. bin/example-image runs the installer and builds
   # what it wrote, so the scaffold an application actually gets is what is under test; bin/conformance then
   # drives the example battery through it from a second container, checking the descriptor crossing the
-  # container boundary, network: none, cap-drop, the read-only root and the noexec tmpfs.
+  # container boundary, network: none, cap-drop, no-new-privileges, the read-only root and the noexec tmpfs.
+  # The negative step then boots the same image without one flag at a time and requires the battery to fail,
+  # so the claim above is a test rather than an assertion: a flag the battery cannot observe would let this
+  # step pass with the protection gone.
   conformance:
     name: "container conformance"
     runs-on: ubuntu-latest
@@ -133,7 +136,22 @@ jobs:
           bundler-cache: true
       - name: Build the example cell image from the installed scaffold
         run: bin/example-image
-      - run: bin/conformance hotcell:example
+      - name: Conformance holds with every flag in place
+        run: bin/conformance hotcell:example
+      # tmpfs-noexec is deliberately not here: some container runtimes (Docker Desktop's LinuxKit among
+      # them) force noexec onto every tmpfs, which would mask the drop and make this step flaky. The
+      # positive run above still asserts the noexec mount, and examples/gate proves the assertion rejects a
+      # tmpfs without it — so noexec stays covered without an environment-dependent negative job.
+      - name: Conformance fails with any one security flag dropped
+        run: |
+          for drop in network read-only cap-drop no-new-privileges; do
+            echo "== booting without --$drop, expecting the battery to fail =="
+            if HOTCELL_CONFORMANCE_DROP="$drop" bin/conformance hotcell:example; then
+              echo "::error::conformance passed without --$drop; the battery does not verify that flag"
+              exit 1
+            fi
+            echo "ok: dropping --$drop failed the battery, as it must"
+          done
 
   # Provenance of the produced image: the cell is the boundary the application relies on, so what it ships
   # is gated the same way its behavior is. bin/example-image builds the installed scaffold, so this scans

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,19 +138,37 @@ jobs:
         run: bin/example-image
       - name: Conformance holds with every flag in place
         run: bin/conformance hotcell:example
-      # tmpfs-noexec is deliberately not here: some container runtimes (Docker Desktop's LinuxKit among
-      # them) force noexec onto every tmpfs, which would mask the drop and make this step flaky. The
-      # positive run above still asserts the noexec mount, and examples/gate proves the assertion rejects a
-      # tmpfs without it — so noexec stays covered without an environment-dependent negative job.
-      - name: Conformance fails with any one security flag dropped
+      # Each drop must fail the battery at its own isolation assertion — not merely exit non-zero, which an
+      # unrelated hiccup (a bundle install outage, a flaky timing check) could also do and be misread as
+      # the flag having been caught. So we require the expected message, which ties the failure to the
+      # dropped flag. --user has no entry: the image already sets USER 10001, so dropping the run flag is a
+      # no-op, and forcing root instead would fail at socket ownership rather than the uid check; the
+      # positive run above already fails if the image ever runs as root, and examples/gate covers the
+      # assertion. tmpfs-noexec is included: runc on this runner honours the tmpfs options, so dropping
+      # noexec produces a scratch the battery rejects (a runtime that force-mounts noexec would surface
+      # here as a passing run, which the message check turns into a loud failure rather than a silent one).
+      - name: Conformance fails at the intended check with any one security flag dropped
         run: |
-          for drop in network read-only cap-drop no-new-privileges; do
-            echo "== booting without --$drop, expecting the battery to fail =="
-            if HOTCELL_CONFORMANCE_DROP="$drop" bin/conformance hotcell:example; then
+          declare -A expect=(
+            [network]="network interfaces"
+            [read-only]="not mounted read-only"
+            [tmpfs-noexec]="not mounted noexec"
+            [cap-drop]="bounding capability set"
+            [no-new-privileges]="gain new privileges"
+          )
+          for drop in "${!expect[@]}"; do
+            echo "== booting without --$drop, expecting failure at: ${expect[$drop]} =="
+            if out="$(HOTCELL_CONFORMANCE_DROP="$drop" bin/conformance hotcell:example 2>&1)"; then
+              echo "$out"
               echo "::error::conformance passed without --$drop; the battery does not verify that flag"
               exit 1
             fi
-            echo "ok: dropping --$drop failed the battery, as it must"
+            if ! grep -qF "${expect[$drop]}" <<<"$out"; then
+              echo "$out"
+              echo "::error::without --$drop the run failed, but not at the ${expect[$drop]} check; the failure is unrelated"
+              exit 1
+            fi
+            echo "ok: dropping --$drop failed at '${expect[$drop]}', as it must"
           done
 
   # Provenance of the produced image: the cell is the boundary the application relies on, so what it ships

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,9 @@ jobs:
   # what it wrote, so the scaffold an application actually gets is what is under test; bin/conformance then
   # drives the example battery through it from a second container, checking the descriptor crossing the
   # container boundary, network: none, cap-drop, no-new-privileges, the read-only root and the noexec tmpfs.
-  # The negative step then boots the same image without one flag at a time and requires the battery to fail,
-  # so the claim above is a test rather than an assertion: a flag the battery cannot observe would let this
-  # step pass with the protection gone.
+  # It then boots the same image without one of those flags at a time and requires the battery to fail at
+  # that flag's own check, so the claim above is a test rather than an assertion. Those negative runs live in
+  # the script rather than in this step, so an operator running it against their own image gets them too.
   conformance:
     name: "container conformance"
     runs-on: ubuntu-latest
@@ -136,42 +136,8 @@ jobs:
           bundler-cache: true
       - name: Build the example cell image from the installed scaffold
         run: bin/example-image
-      - name: Conformance holds with every flag in place
+      - name: Conformance holds, and fails with any one security flag dropped
         run: bin/conformance hotcell:example
-      # Each drop must fail the battery at its own isolation assertion — not merely exit non-zero, which an
-      # unrelated hiccup (a bundle install outage, a flaky timing check) could also do and be misread as
-      # the flag having been caught. So we require the expected message, which ties the failure to the
-      # dropped flag. Two flags have no entry:
-      #   --user: the image already sets USER 10001, so dropping the run flag is a no-op, and forcing root
-      #     instead would fail at socket ownership rather than the uid check. The positive run above already
-      #     fails if the image ever runs as root, and examples/gate covers the uid assertion directly.
-      #   tmpfs-noexec: this runner's container runtime force-mounts noexec on every tmpfs, so dropping the
-      #     option still yields a noexec scratch and the negative run would pass — verified empirically when
-      #     it was tried here. The positive run still asserts the noexec mount and examples/gate proves the
-      #     assertion rejects a tmpfs without it, so noexec stays covered without a negative job that the
-      #     environment cannot honour.
-      - name: Conformance fails at the intended check with any one security flag dropped
-        run: |
-          declare -A expect=(
-            [network]="network interfaces"
-            [read-only]="not mounted read-only"
-            [cap-drop]="bounding capability set"
-            [no-new-privileges]="gain new privileges"
-          )
-          for drop in "${!expect[@]}"; do
-            echo "== booting without --$drop, expecting failure at: ${expect[$drop]} =="
-            if out="$(HOTCELL_CONFORMANCE_DROP="$drop" bin/conformance hotcell:example 2>&1)"; then
-              echo "$out"
-              echo "::error::conformance passed without --$drop; the battery does not verify that flag"
-              exit 1
-            fi
-            if ! grep -qF "${expect[$drop]}" <<<"$out"; then
-              echo "$out"
-              echo "::error::without --$drop the run failed, but not at the ${expect[$drop]} check; the failure is unrelated"
-              exit 1
-            fi
-            echo "ok: dropping --$drop failed at '${expect[$drop]}', as it must"
-          done
 
   # Provenance of the produced image: the cell is the boundary the application relies on, so what it ships
   # is gated the same way its behavior is. bin/example-image builds the installed scaffold, so this scans

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,18 +141,20 @@ jobs:
       # Each drop must fail the battery at its own isolation assertion — not merely exit non-zero, which an
       # unrelated hiccup (a bundle install outage, a flaky timing check) could also do and be misread as
       # the flag having been caught. So we require the expected message, which ties the failure to the
-      # dropped flag. --user has no entry: the image already sets USER 10001, so dropping the run flag is a
-      # no-op, and forcing root instead would fail at socket ownership rather than the uid check; the
-      # positive run above already fails if the image ever runs as root, and examples/gate covers the
-      # assertion. tmpfs-noexec is included: runc on this runner honours the tmpfs options, so dropping
-      # noexec produces a scratch the battery rejects (a runtime that force-mounts noexec would surface
-      # here as a passing run, which the message check turns into a loud failure rather than a silent one).
+      # dropped flag. Two flags have no entry:
+      #   --user: the image already sets USER 10001, so dropping the run flag is a no-op, and forcing root
+      #     instead would fail at socket ownership rather than the uid check. The positive run above already
+      #     fails if the image ever runs as root, and examples/gate covers the uid assertion directly.
+      #   tmpfs-noexec: this runner's container runtime force-mounts noexec on every tmpfs, so dropping the
+      #     option still yields a noexec scratch and the negative run would pass — verified empirically when
+      #     it was tried here. The positive run still asserts the noexec mount and examples/gate proves the
+      #     assertion rejects a tmpfs without it, so noexec stays covered without a negative job that the
+      #     environment cannot honour.
       - name: Conformance fails at the intended check with any one security flag dropped
         run: |
           declare -A expect=(
             [network]="network interfaces"
             [read-only]="not mounted read-only"
-            [tmpfs-noexec]="not mounted noexec"
             [cap-drop]="bounding capability set"
             [no-new-privileges]="gain new privileges"
           )

--- a/Rakefile
+++ b/Rakefile
@@ -41,8 +41,14 @@ namespace "test" do
     ruby "examples/devcell"
   end
 
+  desc "Check the conformance gate observes each isolation flag and sets no stack ulimit"
+  task :gate do
+    puts "\n## Checking the conformance gate"
+    ruby "examples/gate"
+  end
+
   desc "Run everything that needs no tools installed"
-  task hotcell: suites(HOTCELL) + [ "test:devcell" ]
+  task hotcell: suites(HOTCELL) + [ "test:gate", "test:devcell" ]
 
   desc "Run everything that needs the converters installed"
   task activestorage: suites(ACTIVE_STORAGE)

--- a/bin/conformance
+++ b/bin/conformance
@@ -21,6 +21,13 @@ CELL="hotcell-conformance-cell-$STAMP"
 VOLUME="hotcell-conformance-$STAMP"
 DIRECTORY="/run/hotcell/cell/conformance"
 
+# Which single security flag to boot without, for the negative conformance jobs. Empty means the real
+# deployment shape; a flag name boots without that one protection and the battery must then fail. This is
+# what proves the battery observes each flag rather than asserting it: a gate that could lose --cap-drop
+# ALL and still pass — which it once could — proves nothing. Recognised: network, read-only, tmpfs-noexec,
+# cap-drop, no-new-privileges. See .github/workflows/ci.yml and docs/DEPLOYMENT.md § Security.
+DROP="${HOTCELL_CONFORMANCE_DROP:-}"
+
 cleanup() {
   docker rm -f "$CELL" >/dev/null 2>&1 || true
   docker volume rm "$VOLUME" >/dev/null 2>&1 || true
@@ -32,23 +39,40 @@ trap cleanup EXIT
 # cell then could not create its own socket. See docs/DEPLOYMENT.md.
 docker volume create "$VOLUME" >/dev/null
 
-echo "booting $IMAGE with the accessory's flags, HOTCELL_DIR=$DIRECTORY"
-docker run --detach --name "$CELL" \
-  --network none \
-  --read-only \
-  --tmpfs /tmp:rw,nosuid,nodev,noexec,size=512m \
-  --memory 2g --memory-swap 2g \
-  --cpus 2 \
-  --pids-limit 512 \
-  --cap-drop ALL \
-  --security-opt no-new-privileges:true \
-  --user 10001:10001 \
-  --ulimit stack=2097152:2097152 \
-  --env HOTCELL_DIR="$DIRECTORY" \
-  --env HOTCELL_OPERATIONS=/hotcell/operations \
-  --volume "$REPO/examples/operations:/hotcell/operations:ro" \
-  --volume "$VOLUME:/run/hotcell/cell" \
-  "$IMAGE" >/dev/null
+# The security flags the accessory sets, added one at a time so a negative job can leave exactly one out.
+# `keep NAME arg...` appends the flag unless it is the one named in DROP. No --ulimit stack: docs/DEPLOYMENT.md
+# forbids it — a lowered stack turns an overflow into a SIGSEGV the cell reports as a permanent killed/memory
+# verdict, so the helper would measure a shape operators are told not to deploy.
+run=(docker run --detach --name "$CELL")
+
+keep() {
+  local name="$1"; shift
+  [ "$name" = "$DROP" ] || run+=("$@")
+}
+
+keep network      --network none
+keep read-only    --read-only
+# tmpfs must stay writable even when noexec is the dropped flag, or the run fails for want of scratch
+# rather than for the missing noexec the battery is meant to catch — so drop the option, not the mount.
+if [ "$DROP" = tmpfs-noexec ]; then
+  run+=(--tmpfs /tmp:rw,nosuid,nodev,size=512m)
+else
+  run+=(--tmpfs /tmp:rw,nosuid,nodev,noexec,size=512m)
+fi
+keep cap-drop          --cap-drop ALL
+keep no-new-privileges --security-opt no-new-privileges:true
+
+# Not part of the negative matrix: the image already sets USER 10001, so dropping --user here would not
+# reach root. The battery still asserts a non-root uid as defence for an image built without USER.
+run+=(--memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --user 10001:10001)
+run+=(--env HOTCELL_DIR="$DIRECTORY")
+run+=(--env HOTCELL_OPERATIONS=/hotcell/operations)
+run+=(--volume "$REPO/examples/operations:/hotcell/operations:ro")
+run+=(--volume "$VOLUME:/run/hotcell/cell")
+run+=("$IMAGE")
+
+echo "booting $IMAGE with the accessory's flags, HOTCELL_DIR=$DIRECTORY${DROP:+ (without --$DROP)}"
+"${run[@]}" >/dev/null
 
 # The driver runs as its own uid and joins the cell's group, which is the deployment the docs describe. As
 # root it would bypass the sockets' 0660 and prove nothing about the group that is meant to be carrying

--- a/bin/conformance
+++ b/bin/conformance
@@ -41,8 +41,9 @@ docker volume create "$VOLUME" >/dev/null
 
 # The security flags the accessory sets, added one at a time so a negative job can leave exactly one out.
 # `keep NAME arg...` appends the flag unless it is the one named in DROP. No --ulimit stack: docs/DEPLOYMENT.md
-# forbids it — a lowered stack turns an overflow into a SIGSEGV the cell reports as a permanent killed/memory
-# verdict, so the helper would measure a shape operators are told not to deploy.
+# forbids it — a lowered stack turns an overflow into a SIGSEGV the cell reports as killed/crashed, a transient
+# verdict the caller retries against a limit that will fail it again, so the helper would measure a shape
+# operators are told not to deploy.
 run=(docker run --detach --name "$CELL")
 
 keep() {

--- a/bin/conformance
+++ b/bin/conformance
@@ -5,6 +5,12 @@
 # a named volume. The socket appearing where HOTCELL_DIR said proves the env contract; the descriptor
 # crossing between the two containers is part of every check; the isolation checks prove the flags held.
 #
+# It then boots the same image again without one security flag at a time and requires the battery to fail
+# at that flag's own check. Without those negative runs the isolation checks are an assertion rather than a
+# test: a battery that never read the bounding capability set passed just as happily with --cap-drop ALL
+# removed, which is the bug this gate was rebuilt to catch. They run against whatever image you point it at,
+# so an operator gets the same proof of their own image that CI gets of the example one.
+#
 # Exits non-zero on the first failed check, so a user or CI can gate on it.
 #
 #   bin/conformance IMAGE [DRIVER_IMAGE]
@@ -21,12 +27,27 @@ CELL="hotcell-conformance-cell-$STAMP"
 VOLUME="hotcell-conformance-$STAMP"
 DIRECTORY="/run/hotcell/cell/conformance"
 
-# Which single security flag to boot without, for the negative conformance jobs. Empty means the real
-# deployment shape; a flag name boots without that one protection and the battery must then fail. This is
-# what proves the battery observes each flag rather than asserting it: a gate that could lose --cap-drop
-# ALL and still pass — which it once could — proves nothing. Recognised: network, read-only, tmpfs-noexec,
-# cap-drop, no-new-privileges. See .github/workflows/ci.yml and docs/DEPLOYMENT.md § Security.
+# Which single security flag to boot without. Empty is the real deployment shape and the whole run: the
+# positive pass followed by the negative matrix below. A flag name is one negative boot on its own, which is
+# how this script re-invokes itself and how you reproduce a single failure by hand.
 DROP="${HOTCELL_CONFORMANCE_DROP:-}"
+
+# The negative matrix, in order: the flag `keep` names, and the text the battery prints when the check for
+# that flag fails. Matching the message rather than accepting any non-zero exit is what ties the failure to
+# the dropped flag — an unrelated hiccup (a bundle install outage, a flaky timing check) would otherwise be
+# misread as the flag having been caught. examples/gate holds each message against the battery's own
+# assertions, so a reworded assertion cannot rot this into a grep that never matches.
+#
+# --user is not here: the image already sets USER 10001, so dropping the run flag reaches no further, and
+# forcing root instead fails at socket ownership rather than at the uid check. The positive run asserts a
+# non-root uid and examples/gate covers the assertion directly.
+NEGATIVES=(
+  "network=network interfaces"
+  "read-only=not mounted read-only"
+  "tmpfs-noexec=not mounted noexec"
+  "cap-drop=bounding capability set"
+  "no-new-privileges=gain new privileges"
+)
 
 cleanup() {
   docker rm -f "$CELL" >/dev/null 2>&1 || true
@@ -63,8 +84,8 @@ fi
 keep cap-drop          --cap-drop ALL
 keep no-new-privileges --security-opt no-new-privileges:true
 
-# Not part of the negative matrix: the image already sets USER 10001, so dropping --user here would not
-# reach root. The battery still asserts a non-root uid as defence for an image built without USER.
+# --user is dropped from no negative run; see NEGATIVES. The battery still asserts a non-root uid as
+# defence for an image built without USER.
 run+=(--memory 2g --memory-swap 2g --cpus 2 --pids-limit 512 --user 10001:10001)
 run+=(--env HOTCELL_DIR="$DIRECTORY")
 run+=(--env HOTCELL_OPERATIONS=/hotcell/operations)
@@ -104,4 +125,75 @@ fi
 echo
 echo "cell log:"
 docker logs "$CELL" 2>&1 | sed 's/^/  /'
+
+if [ -n "$DROP" ]; then
+  echo "PASS: $IMAGE supports hotcell (booted without --$DROP)"
+  exit 0
+fi
+
 echo "PASS: $IMAGE supports hotcell"
+
+# The positive cell has answered everything it is going to; each negative run boots its own.
+cleanup
+
+# Whether this runtime honours a tmpfs mounted without noexec. Docker Desktop's LinuxKit VM and GitHub's
+# runner both force noexec onto every tmpfs, and there the negative run boots a noexec scratch, passes, and
+# would report a working battery as broken. Ask the runtime rather than assume either way. 0 honoured,
+# 1 forced, 2 unanswerable.
+tmpfs_option_honoured() {
+  local mounts
+  mounts="$(docker run --rm --tmpfs /tmp:rw,nosuid,nodev,size=16m --entrypoint sh "$IMAGE" \
+    -c 'grep " /tmp " /proc/self/mounts' 2>/dev/null)" || return 2
+  case "$mounts" in
+    *noexec*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+echo
+echo "## Negative runs: each flag dropped in turn must fail the battery at its own check"
+
+failures=0
+
+for entry in "${NEGATIVES[@]}"; do
+  flag="${entry%%=*}"
+  expected="${entry#*=}"
+
+  if [ "$flag" = tmpfs-noexec ]; then
+    tmpfs_option_honoured && honoured=0 || honoured=$?
+    if [ "$honoured" -ne 0 ]; then
+      echo
+      if [ "$honoured" -eq 1 ]; then
+        echo "SKIP --tmpfs noexec: this runtime force-mounts noexec on every tmpfs, so a run without the"
+        echo "     option still gets a noexec scratch and could only fail for the wrong reason."
+      else
+        echo "SKIP --tmpfs noexec: could not read the scratch mount options from $IMAGE to tell whether this"
+        echo "     runtime honours the option."
+      fi
+      echo "     The positive run above still asserts the noexec mount."
+      continue
+    fi
+  fi
+
+  echo
+  echo "== booting without --$flag, expecting failure at: $expected =="
+  if out="$(HOTCELL_CONFORMANCE_DROP="$flag" "$0" "$IMAGE" "$DRIVER_IMAGE" 2>&1)"; then
+    echo "$out" | sed 's/^/  /'
+    echo "FAIL: conformance passed without --$flag, so the battery does not verify that flag"
+    failures=$((failures + 1))
+  elif ! grep -qF "$expected" <<<"$out"; then
+    echo "$out" | sed 's/^/  /'
+    echo "FAIL: without --$flag the run failed, but not at the '$expected' check, so the failure is unrelated"
+    failures=$((failures + 1))
+  else
+    echo "ok: dropping --$flag failed at '$expected', as it must"
+  fi
+done
+
+echo
+if [ "$failures" -gt 0 ]; then
+  echo "FAIL: $failures negative run(s) did not fail the way they must"
+  exit 1
+fi
+
+echo "PASS: $IMAGE supports hotcell, and the battery verifies each flag it reports on"

--- a/bin/load
+++ b/bin/load
@@ -42,7 +42,6 @@ docker run --detach --name "$CELL" \
   --cap-drop ALL \
   --security-opt no-new-privileges:true \
   --user 10001:10001 \
-  --ulimit stack=2097152:2097152 \
   --env EXAMPLE_CONCURRENCY \
   --env EXAMPLE_QUEUE_SIZE \
   --env EXAMPLE_QUEUE_WAIT \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -110,10 +110,11 @@ through /proc/<pid>/mem. No container flag can set it. Set it to 1 or higher and
 
 A host that does not expose the file at all logs `cell.ptrace_scope_unknown` and boots anyway.
 
-**The security flags it cannot observe.** It reads three from inside the cell: `network: none` (the only
-interface is `lo`), `read-only` (the root filesystem refuses a write), and the tmpfs `noexec` flag. It does
-not observe `cap-drop`, `no-new-privileges`, the uid, the tmpfs `nosuid` and `nodev` flags, or
-`pids-limit`. Those are yours to get right, and "Verifying your accessory" is how.
+**The security flags it cannot observe.** It reads six from inside the cell: `network: none` (the only
+interface is `lo`), `read-only` (the root filesystem is mounted `ro`), the tmpfs `noexec` flag, `cap-drop`
+(the bounding capability set is empty), `no-new-privileges`, and the uid. A flag the cell cannot read fails
+the check rather than passing it. It does not observe the tmpfs `nosuid` and `nodev` flags, `pids-limit`,
+or the resource limits. Those are yours to get right, and "Verifying your accessory" is how.
 
 **Your application's group membership.** Conformance does check the shared group, because it runs the cell
 as `10001` against files a different user owns: `example.reopen` proves a cell can open an input by name,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -86,6 +86,12 @@ under "Container settings", mounts the example operations over `/hotcell/operati
 battery of checks from a second container over a shared volume: descriptor round-trips, each kill
 verdict, refusal at capacity, and the isolation flags. It exits non-zero on the first failed check.
 
+It then runs the same battery again against your image booted without one security flag at a time, and
+requires each run to fail at that flag's own check. That is what makes the isolation results a test of
+the flags rather than a restatement of them: a check that cannot see a flag would pass a cell running
+without it. A runtime that force-mounts `noexec` onto every tmpfs — Docker Desktop does — cannot host
+the `noexec` negative, and that one run reports `SKIP` with the reason.
+
 ```
 docker build -t my-cell:test hotcell/
 bin/conformance my-cell:test

--- a/examples/gate
+++ b/examples/gate
@@ -4,16 +4,18 @@
 # The parts of the conformance gate that need neither a container nor a toolchain, so they run in the
 # no-toolchain suite alongside the development cell. Two regressions live here:
 #
-#   1. The battery's isolation check must observe every container security flag, and must treat a flag it
-#      cannot read as a failure rather than silence. The purple-team assessment removed the accessory's
+#   1. The battery's isolation check must observe each isolation flag conformance claims — the network,
+#      the read-only root, the noexec scratch, cap-drop, no-new-privileges, and the uid — and must treat a
+#      flag it cannot read as a failure rather than silence. The purple-team assessment removed the accessory's
 #      --cap-drop ALL as a negative control and every check still passed, because the battery never read
 #      the bounding capability set. This drives the check with a fake isolation result and proves it now
 #      rejects a non-empty capability set, a cleared no-new-privileges bit, a root uid, and — crucially —
 #      a nil for any of them, the shape a cell that cannot report a flag would return.
 #
 #   2. bin/conformance and bin/load must supply no `--ulimit stack`. docs/DEPLOYMENT.md forbids it: a
-#      lowered stack turns an overflow into a SIGSEGV the cell reports as a permanent killed/memory
-#      verdict, so a helper that set it would measure a shape operators are told not to deploy.
+#      lowered stack turns an overflow into a SIGSEGV the cell reports as killed/crashed, a transient
+#      verdict the caller retries against a limit that will fail it again, so a helper that set it would
+#      measure a shape operators are told not to deploy.
 #
 # The container conformance run and its negative jobs (see .github/workflows/ci.yml) are the end-to-end
 # proof; this is the fast guard that keeps the gate honest without Docker.

--- a/examples/gate
+++ b/examples/gate
@@ -97,6 +97,28 @@ end
   end
 end
 
+# The negative matrix lives in bin/conformance rather than in CI, so an operator running it against their
+# own image gets the negative controls too — a positive-only run is the vacuous shape this gate exists to
+# reject. Each negative greps the battery's output for the assertion belonging to the dropped flag, so the
+# text it looks for must be text the battery can actually print: a reworded assertion would otherwise turn
+# the negative run into a grep that never matches, passing for the wrong reason.
+CONFORMANCE = File.read(File.join(REPO, "bin/conformance"))
+ISOLATION_ASSERTIONS = File.read(File.join(REPO, "examples/lib/battery.rb"))[/def isolation\b.*?^      end$/m].to_s
+
+NEGATIVES = CONFORMANCE.scan(/^\s*"([a-z-]+)=([^"]+)"$/).to_h
+
+check("bin/conformance runs a negative for every flag it can drop") do
+  droppable = CONFORMANCE.scan(/^keep +([a-z-]+)/).flatten + [ "tmpfs-noexec" ]
+  missing = droppable.uniq.sort - NEGATIVES.keys
+  raise "no negative run for #{missing.join(", ")}" if missing.any?
+end
+
+NEGATIVES.each do |flag, message|
+  check("the negative run for #{flag} looks for a message the battery prints") do
+    raise "no isolation assertion contains #{message.inspect}" unless ISOLATION_ASSERTIONS.include?(message)
+  end
+end
+
 if FAILURES.empty?
   puts "PASS"
 else

--- a/examples/gate
+++ b/examples/gate
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# The parts of the conformance gate that need neither a container nor a toolchain, so they run in the
+# no-toolchain suite alongside the development cell. Two regressions live here:
+#
+#   1. The battery's isolation check must observe every container security flag, and must treat a flag it
+#      cannot read as a failure rather than silence. The purple-team assessment removed the accessory's
+#      --cap-drop ALL as a negative control and every check still passed, because the battery never read
+#      the bounding capability set. This drives the check with a fake isolation result and proves it now
+#      rejects a non-empty capability set, a cleared no-new-privileges bit, a root uid, and — crucially —
+#      a nil for any of them, the shape a cell that cannot report a flag would return.
+#
+#   2. bin/conformance and bin/load must supply no `--ulimit stack`. docs/DEPLOYMENT.md forbids it: a
+#      lowered stack turns an overflow into a SIGSEGV the cell reports as a permanent killed/memory
+#      verdict, so a helper that set it would measure a shape operators are told not to deploy.
+#
+# The container conformance run and its negative jobs (see .github/workflows/ci.yml) are the end-to-end
+# proof; this is the fast guard that keeps the gate honest without Docker.
+
+require "bundler/setup"
+require_relative "lib/battery"
+
+REPO = File.expand_path("..", __dir__)
+FAILURES = []
+
+def check(name)
+  yield
+  puts "  ok #{name}"
+rescue StandardError => error
+  FAILURES << "#{name}: #{error.message}"
+  puts "  FAIL #{name}: #{error.message}"
+end
+
+# Drives Battery#isolation against a fixed isolation result, without a cell.
+def with_isolation_result(result)
+  Examples::Isolation.singleton_class.send(:define_method, :perform_in_hotcell) { |*| result }
+  yield
+ensure
+  Examples::Isolation.singleton_class.send(:remove_method, :perform_in_hotcell)
+end
+
+def isolation_raises?(result)
+  with_isolation_result(result) do
+    Examples::Battery.new(cell: nil, isolation: true).send(:isolation)
+    false
+  rescue Examples::Battery::Failed
+    true
+  end
+end
+
+SECURE = {
+  interfaces: [ "lo" ],
+  writable_root: false,
+  root_readonly: true,
+  scratch_noexec: true,
+  cap_bound: 0,
+  no_new_privs: true,
+  uid: 10001,
+  tool_env: %w[ HOME LANG LC_ALL PATH ],
+}.freeze
+
+# The full deployment shape passes.
+check("the isolation check passes when every flag holds") do
+  raise "the secure result did not pass" if isolation_raises?(SECURE)
+end
+
+# Each flag, wrong or unreadable, must fail — including nil, so a cell that cannot report a flag is never
+# read as a pass. cap_bound and no_new_privs and uid are the newly-observed flags; the rest guard the
+# ones the battery already checked.
+{
+  "a non-empty bounding capability set (cap-drop ALL not in effect)" => { cap_bound: 0xa80425fb },
+  "an unreadable bounding capability set"                            => { cap_bound: nil },
+  "a cleared no-new-privileges bit"                                 => { no_new_privs: false },
+  "an unreadable no-new-privileges bit"                             => { no_new_privs: nil },
+  "a root uid" => { uid: 0 },
+  "an unreadable uid" => { uid: nil },
+  "an extra network interface" => { interfaces: %w[ eth0 lo ] },
+  "a writable root filesystem" => { writable_root: true },
+  "a root filesystem not mounted read-only" => { root_readonly: false },
+  "an unreadable root mount" => { root_readonly: nil },
+  "a scratch that is not noexec" => { scratch_noexec: false },
+}.each do |description, override|
+  check("the isolation check fails on #{description}") do
+    raise "the battery accepted it" unless isolation_raises?(SECURE.merge(override))
+  end
+end
+
+# No stack ulimit in either helper.
+%w[ bin/conformance bin/load ].each do |script|
+  check("#{script} supplies no --ulimit stack") do
+    # Comment lines are allowed to name the flag they forbid; only a live command line counts.
+    code = File.readlines(File.join(REPO, script)).grep_v(/\A\s*#/).join
+    raise "found a stack ulimit" if code.match?(/--ulimit[=\s]+stack/)
+  end
+end
+
+if FAILURES.empty?
+  puts "PASS"
+else
+  warn "FAIL: #{FAILURES.size} check(s) failed"
+  exit 1
+end

--- a/examples/lib/battery.rb
+++ b/examples/lib/battery.rb
@@ -171,7 +171,16 @@ module Examples
 
         assert_equal [ "lo" ], result[:interfaces], "the cell's network interfaces"
         assert_equal false, result[:writable_root], "the cell's root filesystem took a write"
+        assert_equal true, result[:root_readonly], "the cell's root filesystem is not mounted read-only"
         assert_equal true, result[:scratch_noexec], "the cell's scratch is not mounted noexec"
+
+        # The container security flags. Each asserts the flag held, and a nil — the cell could not read the
+        # field — fails rather than passes, so a run that cannot see a capability is never mistaken for one
+        # that dropped it. This is the assertion ci.yml claims and, before it, did not make: without it the
+        # accessory's cap-drop ALL could be removed and every check still passed.
+        assert_equal 0, result[:cap_bound], "the cell's bounding capability set is non-empty (cap-drop ALL not in effect)"
+        assert_equal true, result[:no_new_privs], "the cell can gain new privileges (no-new-privileges not set)"
+        assert result[:uid].to_i.positive?, "the cell runs as root or could not report its uid: #{result[:uid].inspect}"
 
         assert result[:tool_env], "the env tool could not run inside the cell"
         extra = result[:tool_env] - %w[ HOME LANG LC_ALL PATH ]

--- a/examples/lib/battery.rb
+++ b/examples/lib/battery.rb
@@ -28,6 +28,15 @@ module Examples
     end
 
     def run
+      # The container shape comes first, before the timing-sensitive functional checks. A negative
+      # conformance run boots without one isolation flag and must fail here, at the flag it dropped; run
+      # last, it would first have to pass deadline, overload and the rest, and a flake in any of those
+      # would fail the run for a reason unrelated to the flag — reading as though the flag had been caught.
+      if @isolation
+        check("the isolation holds") { isolation }
+        check("a cell cannot widen what it was given") { tamper }
+      end
+
       check("describe lists the example operations") { describe }
       check("echo round-trips through the caller's descriptors") { echo }
       check("an operation re-opens both descriptors by path") { reopen }
@@ -46,8 +55,6 @@ module Examples
       check("offered overload answers capacity") { overload }
       check("the cell keeps serving afterwards") { still_serving }
       check("metrics answer on the control socket") { metrics }
-      check("the isolation holds") { isolation } if @isolation
-      check("a cell cannot widen what it was given") { tamper } if @isolation
 
       true
     end

--- a/examples/operations/isolation.rb
+++ b/examples/operations/isolation.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 # What a worker can see of its container, for the checks only a containerized run can make: the network
-# interfaces, whether the root filesystem takes a write, whether scratch is mounted noexec, and what an
-# exec'd tool sees of the environment. Each answers nil where the platform cannot say (macOS has no /sys
-# and no /proc), so the same file loads in a native development cell.
+# interfaces, whether the root filesystem takes a write, whether scratch is mounted noexec, the container
+# security flags the kernel exposes in /proc/self/status — the bounding capability set (cap-drop), the
+# no-new-privileges bit, and the uid the cell runs as — and what an exec'd tool sees of the environment.
+# Each answers nil where the platform cannot say (macOS has no /sys and no /proc), so the same file loads
+# in a native development cell; the battery reads that nil as a failed check rather than a pass, so a cell
+# that cannot report a flag never passes for silence.
 module Examples
   class Isolation < HotCell::Operation
     operation "example.isolation"
@@ -13,7 +16,11 @@ module Examples
 
       { interfaces: interfaces,
         writable_root: File.writable?("/"),
+        root_readonly: root_readonly,
         scratch_noexec: scratch_noexec?,
+        cap_bound: cap_bound,
+        no_new_privs: no_new_privs,
+        uid: Process.uid,
         tool_env: tool.ok? ? tool.out.lines.map { |line| line.split("=", 2).first }.sort : nil }
     end
 
@@ -22,10 +29,45 @@ module Examples
         Dir.exist?("/sys/class/net") ? Dir.children("/sys/class/net").sort : nil
       end
 
+      # Whether the root filesystem is mounted read-only, read from its mount options rather than from
+      # File.writable?("/"): the cell runs as a non-root user, so `/` is unwritable to it whether or not
+      # the container is read-only, and only the mount flag distinguishes the two.
+      def root_readonly
+        options = mount_options("/")
+        options && options.include?("ro")
+      end
+
       def scratch_noexec?
+        options = mount_options("/tmp")
+        options && options.include?("noexec")
+      end
+
+      def mount_options(mountpoint)
         return nil unless File.exist?("/proc/self/mounts")
 
-        File.read("/proc/self/mounts").lines.grep(%r{ /tmp .*noexec}).any?
+        line = File.foreach("/proc/self/mounts").find { |mount| mount.split(" ")[1] == mountpoint }
+        line && line.split(" ")[3].split(",")
+      end
+
+      # The bounding capability set as an integer: 0 once the accessory's cap-drop ALL has taken it away,
+      # and a non-zero mask (Docker's default is 0x00000000a80425fb) when it has not.
+      def cap_bound
+        field = status_field("CapBnd")
+        field && Integer(field, 16)
+      end
+
+      # Whether the no-new-privileges bit is set, which is what stops a setuid binary regaining a dropped
+      # capability. The kernel writes it as 1 or 0.
+      def no_new_privs
+        field = status_field("NoNewPrivs")
+        field && field == "1"
+      end
+
+      def status_field(name)
+        return nil unless File.exist?("/proc/self/status")
+
+        line = File.foreach("/proc/self/status").find { |candidate| candidate.start_with?("#{name}:") }
+        line&.split(":", 2)&.last&.strip
       end
   end
 end


### PR DESCRIPTION
## Problem

The container conformance battery (`bin/conformance` → `examples/conformance` → `Examples::Battery`) advertises, in `ci.yml` and its own header, that it proves the accessory's isolation flags held. Its isolation check did not. It read only the network interfaces, whether the root filesystem took a write, whether scratch was `noexec`, and what an exec'd tool saw of the environment — and never read the bounding capability set. So `--cap-drop ALL` could be removed from the run and every check still passed: the gate *asserted* the flag rather than *testing* it.

Two further gaps surfaced from the same root cause:

- **`--read-only` was effectively unverified.** `File.writable?("/")` is `false` for the cell's non-root user whether or not the container is read-only (`/` is root-owned), so dropping `--read-only` went unnoticed.
- **The negative controls lived in `ci.yml`.** So the only image they ever tested was `hotcell:example` on a GitHub runner. An operator pointing `bin/conformance` at their own image got the positive pass alone — the same vacuous shape, one level up.
- **`bin/conformance` and `bin/load` forced `--ulimit stack=2097152:2097152`**, which `docs/DEPLOYMENT.md` explicitly forbids: a lowered stack turns an overflow into a `SIGSEGV` the cell reports as `killed`/`crashed`, a transient verdict the caller retries against a limit that will fail it again, with nothing pointing at the setting that caused it. The helpers measured a shape operators are told not to deploy.

## Fix

- `examples/operations/isolation.rb` now reports the flags the kernel exposes: the bounding capability set and the no-new-privileges bit from `/proc/self/status`, `Process.uid`, and the root mount's read-only option from `/proc/self/mounts`. Each answers `nil` where the platform cannot say.
- `Examples::Battery#isolation` requires each: an empty capability set, no-new-privileges set, a non-root uid, and a read-only root. A field that comes back `nil` **fails** the check, so a run that cannot read a flag is never mistaken for one that set it — the vacuous-pass that caused this bug cannot recur silently.
- The isolation checks now run **first** in the battery. A negative conformance run that drops a flag fails there immediately, before the timing-sensitive deadline/overload checks — so a flake in one of those can no longer fail the run for a reason unrelated to the dropped flag.
- **`bin/conformance` runs the negative matrix itself**, after the positive pass, against whatever image you point it at. It re-invokes itself once per flag — `network`, `read-only`, `tmpfs-noexec`, `cap-drop`, `no-new-privileges` — and **requires each run to fail at that flag's own assertion**, matching the expected message rather than accepting any non-zero exit, so an unrelated hiccup fails the run loudly instead of passing for the wrong reason. `HOTCELL_CONFORMANCE_DROP` still boots one named drop on its own, which is how the script re-invokes itself and how you reproduce a single failure by hand. `ci.yml` is back to one step.
- The `tmpfs-noexec` negative is **decided by probing the runtime** rather than excluded by hand. Docker Desktop and GitHub's runner force `noexec` onto every tmpfs, and there the negative would boot a `noexec` scratch, pass, and report a working battery as broken. `bin/conformance` reads the scratch mount options from the image first: a runtime that honours the option gets the check, one that does not reports `SKIP` with the reason.
- `--user` has no negative run by design: the image already sets `USER 10001`, so dropping the run flag is a no-op, and forcing root instead would fail at socket ownership rather than the uid check. The positive run already fails if the image ever runs as root, and the hermetic test covers the uid assertion.
- `--ulimit stack` removed from both helpers.
- `docs/DEPLOYMENT.md` updated: the "security flags it cannot observe" section now lists the six flags conformance reads, says `read-only` is read from the root mount options rather than a write attempt, and narrows the not-observed list to the tmpfs `nosuid`/`nodev` options, `pids-limit`, and the resource limits.

## Tests

- **`examples/gate`** (new, wired into `rake test:hotcell` — the no-toolchain suite): drives the isolation check with fabricated results and proves it rejects a non-empty capability set, a cleared no-new-privileges bit, a root uid, a writable/`rw` root, a non-`noexec` scratch, an extra interface — **and a `nil` for any of them** — while accepting the full secure shape. Also asserts neither helper script sets a stack ulimit. Container-free, so it runs on the macOS lane too.
- **`examples/gate` also holds `bin/conformance` to its own matrix**: every flag `keep` can drop has a negative run, and each expected message is checked against the battery's isolation assertions — so a reworded assertion cannot rot a negative into a grep that never matches.
- **The negative runs** are the end-to-end proof, and now run wherever `bin/conformance` runs rather than only in CI.

## Verification performed

- `rake test:hotcell` green (no-toolchain suite, incl. the new gate and devcell).
- `examples/gate` fails on the pre-fix battery (7 checks) and passes after — confirmed by swapping in the original files.
- End-to-end with Docker: one `bin/conformance hotcell:example` runs the positive pass and then all five negatives. `network`, `read-only`, `cap-drop` and `no-new-privileges` each fail at exactly their intended assertion; `tmpfs-noexec` reports `SKIP` because this host's runtime force-mounts `noexec`, detected by the probe rather than assumed.
- **Adversarially checked that the gate still bites:** commenting out the `cap_bound` assertion in `Examples::Battery#isolation` turns the run into `FAIL: conformance passed without --cap-drop, so the battery does not verify that flag`, exit 1. That is the original bug, and the gate now catches it.
- Credential/PII scanned; no internal identifiers in this public repo.


