### PR TITLE
Remove the missing-operation boot warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This changelog covers five gems, which release together on the same version:
 
 ## next / unreleased
 
+### HotCell::Client
+
+#### Breaking
+
+* `HotCell.describe_cells` no longer warns about a client whose operation the cell does not carry, and `HotCell.clients` is gone with it. The check could not tell a client the application calls from one it merely loaded, so a cell carrying a subset of what a gem ships warned on every boot. A request for an operation a cell does not carry is refused as `unsupported`, naming the operation, and that failure is transient and reaches the application's error reporting. An application that wants a boot check can write one over its own configuration.
+
 
 ## v0.2.0 / 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ class for each side of the permanent split:
 HotCell.root  = ENV["HOTCELL_ROOT"]  # unset means every cell is off
 HotCell.group = ENV["HOTCELL_GROUP"] # the gid shared between app and cell
 
-# Quick health check at boot. Warns about a cell that is unreachable, missing an operation, or in the wrong group.
+# Quick health check at boot. Warns about a cell that is unreachable, slower than this client waits, or in the wrong group.
 Rails.application.config.after_initialize { HotCell.describe_cells }
 ```
 

--- a/activestorage-hotcell-client/lib/active_storage/hot_cell/client.rb
+++ b/activestorage-hotcell-client/lib/active_storage/hot_cell/client.rb
@@ -39,9 +39,8 @@ module ActiveStorage
       RETRY = { wait: :polynomially_longer, attempts: 10 }.freeze
 
       # The clients this gem ships, which is where the retry hook learns which cells' transient classes
-      # the jobs must retry. Deliberately not HotCell.clients: that records every client the process loaded,
-      # including an application's own for unrelated cells, and Active Storage's jobs have no business
-      # retrying those.
+      # the jobs must retry. Listed rather than discovered, so an application's own clients for unrelated
+      # cells stay out of it: Active Storage's jobs have no business retrying those.
       CLIENTS = [ Operations::Transformers::Image::Vips, Operations::Transformers::Image::Magick,
                   Operations::Analyzers::Image::Vips, Operations::Analyzers::Image::Magick,
                   Operations::Analyzers::Media::Ffprobe,

--- a/hotcell-client/lib/hot_cell/cell.rb
+++ b/hotcell-client/lib/hot_cell/cell.rb
@@ -66,14 +66,13 @@ module HotCell
       @on_contract_skew&.call error, self
     end
 
-    # Static, and called once at boot. The cheapest way to catch a client pointed at a cell that does not
-    # carry the operation it wants, which is otherwise an `unsupported` on the first real request.
+    # Static, and called once at boot.
     #
     # Boot must not fail when a cell does not answer. A cell that is down at app boot is a degraded
     # deployment rather than a broken one, and an application that refuses to start because its thumbnail
     # cell is restarting is worse than one that serves placeholders. So this warns and carries on.
     #
-    # Nor when a cell answers something this client cannot read. The three warnings below reach into the
+    # Nor when a cell answers something this client cannot read. The two warnings below reach into the
     # description without checking types, so a cell that sends the wrong ones raises here — and the README
     # calls `describe_cells` from `after_initialize`, where that is not a failed check but an application
     # that does not boot. The process that wrote the description is the one that runs untrusted content.
@@ -86,7 +85,6 @@ module HotCell
 
       response.result.tap do |described|
         warn_about_timeout described
-        warn_about_missing_operations described
         warn_about_group_skew described
       end
     rescue StandardError => error
@@ -162,16 +160,6 @@ module HotCell
         HotCell.logger.warn "hotcell #{name}: HotCell.group is #{HotCell.group} and this cell runs in " \
                             "#{carried.inspect}, so it cannot open a file this application hands it and " \
                             "every operation that gives a tool a filename will fail with EACCES."
-      end
-
-      def warn_about_missing_operations(described)
-        carried = Array(described[:operations])
-        wanted = HotCell.clients.select { |client| client.hotcell == name }
-
-        wanted.reject { |client| carried.include?(client.operation) }.each do |client|
-          HotCell.logger.warn "hotcell #{name}: #{client} wants #{client.operation.inspect} and this cell " \
-                              "carries #{carried.inspect}"
-        end
       end
 
       # A `nil` timeout reaches `Transport::Socket#receive` as `deadline: nil`, and reading with no deadline

--- a/hotcell-client/lib/hot_cell/cells.rb
+++ b/hotcell-client/lib/hot_cell/cells.rb
@@ -60,13 +60,6 @@ module HotCell
       cells.key?(name.to_s)
     end
 
-    # Every HotCell::Client subclass, so a boot check can tell which cell is expected to carry what. This
-    # records what the process has loaded rather than what it has configured, so resetting registrations
-    # leaves it alone: the classes are still defined either way.
-    def clients
-      @clients ||= []
-    end
-
     # Call once at boot, after registering. Warns and carries on; see Cell#describe.
     def describe_cells
       warn_about_group

--- a/hotcell-client/lib/hot_cell/client.rb
+++ b/hotcell-client/lib/hot_cell/client.rb
@@ -40,11 +40,6 @@ module HotCell
     class << self
       include Declarations
 
-      def inherited(subclass)
-        super
-        HotCell.clients << subclass
-      end
-
       def hotcell(name = nil)
         return inherited_value(:@cell_name) if name.nil?
 

--- a/hotcell-client/test/client_test.rb
+++ b/hotcell-client/test/client_test.rb
@@ -28,10 +28,6 @@ class ClientTest < HotCellClientTest
     assert_match "must name its cell", error.message
   end
 
-  def test_every_client_is_discoverable_so_a_boot_check_can_find_it
-    assert_includes HotCell.clients, Uppercase
-  end
-
   # The caller is the one that knows what to do instead, so this is loud rather than silent.
   def test_calling_a_cell_whose_directory_is_unset
     HotCell.register "test"

--- a/hotcell-client/test/integration_test.rb
+++ b/hotcell-client/test/integration_test.rb
@@ -183,15 +183,6 @@ class IntegrationTest < HotCellClientTest
     end
   end
 
-  # Otherwise this is an `unsupported` on the first real request, which is a bad place to learn it.
-  def test_describe_warns_when_the_cell_does_not_carry_what_a_client_wants
-    with_cell do
-      warnings = capturing_warnings { HotCell.describe_cells }
-
-      assert_match "IntegrationTest::Absent wants \"test.absent\"", warnings
-    end
-  end
-
   # A cell that is down at app boot is a degraded deployment, not a broken one. An application that refuses
   # to start because its thumbnail cell is restarting is worse than one that serves placeholders.
   def test_describe_warns_and_carries_on_when_a_cell_does_not_answer
@@ -283,12 +274,6 @@ class IntegrationTest < HotCellClientTest
   class Blocking < HotCell::Client
     hotcell "test"
     operation "test.blocking"
-  end
-
-  # Named after nothing the cell carries, to prove the boot check notices.
-  class Absent < HotCell::Client
-    hotcell "test"
-    operation "test.absent"
   end
 
   private

--- a/hotcell-core/lib/hot_cell/codes.rb
+++ b/hotcell-core/lib/hot_cell/codes.rb
@@ -47,9 +47,9 @@ module HotCell
     # updated by a deploy, so an application that ships a client for a new operation before anybody reboots
     # the cell gets `unsupported` at one hundred percent for as long as that takes.
     #
-    # The two mistakes are not symmetrical. Retrying a caller's typo costs some work and shows up in the
-    # `unsupported` rate and in the client's boot-time warning. Recording a deploy window as permanent
-    # condemns every blob uploaded during it, and needs a hand-written backfill to undo.
+    # The two mistakes are not symmetrical. Retrying a caller's typo costs some work, and it says which
+    # operation in the refusal `worker.rb` writes and in the `unsupported` rate. Recording a deploy window
+    # as permanent condemns every blob uploaded during it, and needs a hand-written backfill to undo.
 
     # `killed` splits on what the worker hit, because a caller cannot otherwise tell a decompression
     # bomb from a slow afternoon. Size and memory are properties of the input, so the same bytes will

--- a/hotcell-core/test/codes_test.rb
+++ b/hotcell-core/test/codes_test.rb
@@ -27,7 +27,7 @@ class CodesTest < HotCellTest
   # An accessory is not updated by a deploy, so an application that ships a client for a new operation before
   # anybody reboots the cell gets this at one hundred percent for as long as that takes. Recording it as
   # permanent condemns every blob uploaded during the window, and a caller's typo shows up in the rate and in
-  # the client's boot-time warning instead.
+  # the refusal, which names the operation.
   def test_an_operation_a_cell_does_not_carry_yet_is_a_deploy_window_rather_than_a_verdict
     refute HotCell::Codes.permanent?("unsupported")
   end

--- a/hotcell-server/lib/hot_cell/control.rb
+++ b/hotcell-server/lib/hot_cell/control.rb
@@ -39,8 +39,7 @@ module HotCell
     end
 
     # Static, and called once per registered cell at app boot. It is the cheapest way to catch a client
-    # pointed at a cell that does not carry the operation it wants, which is otherwise an `unsupported` on
-    # the first real request, and to catch a client whose own timeout is below what this cell may take.
+    # whose own timeout is below what this cell may take, and it is what `bin/hotcell describe` reads.
     def describe
       { v: PROTOCOL_VERSION, operations: Registry.names, groups: groups, **@configuration.to_h }
     end

--- a/hotcell-server/test/cell_test.rb
+++ b/hotcell-server/test/cell_test.rb
@@ -91,7 +91,7 @@ class CellTest < HotCellServerTest
   # Transient, and the design document says otherwise. An accessory is not updated by a deploy, so an
   # application that ships a client for a new operation before anybody reboots the cell gets this at one
   # hundred percent until they do — and recording that as permanent condemns every blob uploaded during the
-  # window. A caller's typo shows up in the `unsupported` rate and in the client's boot-time warning instead.
+  # window. A caller's typo shows up in the `unsupported` rate and in the refusal, which names the operation.
   def test_an_unknown_operation_is_a_deploy_window_rather_than_a_verdict_on_the_input
     TestCell.boot do |cell|
       failure = assert_failed "unsupported", cell.call("test.nonexistent")


### PR DESCRIPTION
`Cell#describe` ran a check once per boot against every client the process had loaded:

    wanted = HotCell.clients.select { |client| client.hotcell == name }

    wanted.reject { |client| carried.include?(client.operation) }.each do |client|
      HotCell.logger.warn "hotcell #{name}: #{client} wants #{client.operation.inspect} and this cell " \
                          "carries #{carried.inspect}"
    end

`HotCell.clients` is what `Client.inherited` accumulated, so it records what the process defined and not what the application calls. Those are not the same set, and the gap is not small: `activestorage-hotcell-client` defines all eight of its clients in one `operations.rb`, and every per-operation file requires it, so subclassing any one client defines the other seven. A cell that deliberately carries a subset of what the gem ships then warns on every correct boot. In bc3 that is two lines every time it starts, naming `Operations::Transformers::Image::Magick` and `Operations::Previewers::Pdf::Poppler`, neither of which the application calls and neither of which is a misconfiguration.

Drop `warn_about_missing_operations`, and `HotCell.clients` and `Client.inherited` with it — the warning was their only reader, so the array and the hook are dead the moment it goes. The tests that covered it go too.

Removed rather than repaired, because every repair needs the check to know which operations the application intends to use, and nothing in the client expresses that intent. Splitting `operations.rb` into one file per client was implemented and does not do it: `CLIENTS` in `activestorage-hotcell-client/lib/active_storage/hot_cell/client.rb` names all eight for the retry hook, so the entry point requires them all regardless. Making the require graph carry the intent works, and costs `require: false` in the application's `Gemfile` plus two hand-ordered requires in place of one — three coordinated changes across two repositories to silence two log lines. An allowlist at `HotCell.register`, or an opt-in marker on the client, treat the symptom and go stale. A warning that fires on every correct boot is worth less than any of that.

What the warning was insurance against is still caught, one layer later. A request for an operation the cell does not carry is refused by `Worker` as `unsupported`, naming the operation, and `unsupported` is transient rather than permanent: the job retries, exhausts and reaches the application's error reporting, and no blob is condemned. `codes.rb` argued the asymmetry between the two failure modes partly from the boot warning's existence, and now argues it from that refusal instead. The same correction lands in `Control#describe`, which claimed the boot check as one of its reasons for existing, and in the `CLIENTS` comment in `activestorage-hotcell-client`, which distinguished itself from `HotCell.clients`.

An application that wants a boot check can write one over its own configuration, which is the thing that actually knows what it uses. `README.md` no longer promises the warning, and `CHANGELOG.md` carries it as a breaking change under `HotCell::Client`.

[#35](https://github.com/basecamp/hotcell/issues/35) argued for the require-graph split mostly on these warnings, and is closed as not planned now that they do not exist.
