### PR TITLE
Pin image converter correctly

### DIFF
--- a/activestorage-hotcell-server/activestorage-hotcell-server.gemspec
+++ b/activestorage-hotcell-server/activestorage-hotcell-server.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "hotcell-server", version
   spec.add_dependency "image_processing", ">= 2.0"
-  spec.add_dependency "mini_magick", ">= 4.0"
-  spec.add_dependency "ruby-vips", ">= 2.2"
+  spec.add_dependency "mini_magick", ">= 5.2.0"
+  spec.add_dependency "ruby-vips", ">= 2.2.1"
 end


### PR DESCRIPTION
activestorage-hotcell-server.gemspec declared mini_magick >= 4.0 and ruby-vips >= 2.2, but the operations call methods only newer versions carry:

- magick_operation.rb sets MiniMagick.restricted_env= at require time (added in mini_magick 5.2.0), and

- vips_operation.rb's before_fork guard requires Vips.block_untrusted (added in ruby-vips 2.2.1).

A bundle that satisfied the declared floors could resolve mini_magick 5.1.2 or ruby-vips 2.2.0 and then fail to boot — NoMethodError on the magick side, a fail-closed ConfigurationError on the vips side — taking the whole conversion toolchain offline.

Raise the floors to the versions that introduce the APIs the code depends on:

  mini_magick >= 5.2.0
  ruby-vips   >= 2.2.1

ref: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10236475016

Supersedes https://github.com/basecamp/hotcell/pull/36/commits