### PR TITLE
Classify ImageProcessing::Error as unreadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ gem but are what an operator runs against their own image.
 
 * `Descriptor#fd_path` answers with the filename behind the descriptor on macOS rather than `/dev/fd/N`. Opening `/dev/fd/N` is a real open on Linux and a `dup(2)` on macOS, where `/dev/fd` has no procfs behind it, so every opener shared one offset: libvips, which opens the path once per candidate loader while it sniffs a format, read past a HEIC file's magic bytes and reported a readable file as `unreadable`. macOS is a development platform for a cell and nothing else — uncontainerized, running as the caller — so this trades away the property that no path the cold side chose is visible to a tool, on the one platform where that path was already within reach. Linux is untouched.
 
+### ActiveStorage::HotCell::Server
+
+#### Fixed
+
+* `MagickOperation` and `VipsOperation` classify `ImageProcessing::Error` as `unreadable`, beside the backend errors it belongs with. It is the pipeline's own verdict on an input against the requested transform — a multi-layer source into a single-layer destination, in the shape that surfaced this. Unclassified it answered `failed`: transient, so the blob was never marked, the application rendered a placeholder against no record, and the same file spent another full conversion on every future request. In production that was a 20.9MB multi-layer image requested with `loader: { page: nil }` into a jpeg, refused after 17 seconds of decode. The in-process path these operations replaced treated `ImageProcessing::Error` as permanent, so this restores prior behaviour rather than adding a verdict that was not there before. The declaration is wider than the multi-layer case and deliberately so: `ImageProcessing::Error` is a bare `StandardError` subclass with no subtypes, and narrowing would mean matching a message string. The two caller-bug shapes reachable through `Transforming#pipeline` — a `loader:` or `saver:` option whose name collides with a Ruby core method on magick, `resize_to_limit` or `resize_to_fit` with both dimensions nil on vips — now answer `unreadable` and permanent along with it.
+
 
 ## v0.3.0 / 2026-09-01
 

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
@@ -50,9 +50,12 @@ module ActiveStorage
         abstract_operation
 
         # MiniMagick::Error is how mini_magick reports a `magick` that exited non-zero — the common shape of an
-        # input it cannot decode. MiniMagick::Invalid is an input `identify` rejects outright. Both are the
-        # input's fault rather than the operation's.
-        unreadable MiniMagick::Error, MiniMagick::Invalid
+        # input it cannot decode. MiniMagick::Invalid is an input `identify` rejects outright.
+        # ImageProcessing::Error is the pipeline's own verdict on the input against the requested
+        # transform — a multi-layer source into a single-layer destination, for example. All three are
+        # the input's fault rather than the operation's; unclassified, each was a transient `failed`
+        # that never marked the blob, so the same file spent a full conversion on every request.
+        unreadable MiniMagick::Error, MiniMagick::Invalid, ImageProcessing::Error
 
         # **Accepted risk.** A tool's output is not bounded on this path. `Operation#run_tool` caps what it
         # reads at 64KB and drops the rest as it arrives, because an input that makes a tool print gigabytes

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/vips_operation.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/vips_operation.rb
@@ -22,8 +22,10 @@ module ActiveStorage
 
         # Vips::Error is how libvips reports a file it cannot decode, which is common rather than exceptional: it
         # covers truncated uploads, formats this build was not compiled with, and formats deliberately refused by
-        # block_untrusted. All of those are the input's fault and none is the operation's.
-        unreadable Vips::Error
+        # block_untrusted. ImageProcessing::Error is the pipeline's own verdict on the input against the
+        # requested transform, classified the same way. All of those are the input's fault and none is
+        # the operation's.
+        unreadable Vips::Error, ImageProcessing::Error
 
         # Requires and configures. It must never evaluate an image, and the reason is mechanical: libvips starts
         # its thread pool on the first evaluation, that pool does not survive fork, and the child then waits on a

--- a/activestorage-hotcell-server/test/magick_transform_image_test.rb
+++ b/activestorage-hotcell-server/test/magick_transform_image_test.rb
@@ -49,6 +49,24 @@ class MagickTransformImageTest < ActiveStorageHotCellTest
     end
   end
 
+  # The production shape that surfaced this: a multi-layer source, its frames kept by
+  # `loader: { page: nil }`, into a single-layer destination. ImageProcessing refuses the
+  # combination, which is a verdict on the input — unclassified it was a transient `failed`
+  # that never marked the blob, so the same file spent a full conversion on every request.
+  def test_a_multi_layer_source_into_a_single_layer_format_is_unreadable
+    Cell.boot do |cell|
+      with_output(".jpg") do |destination|
+        failure = assert_failed "unreadable", cell.call("active_storage.transformers.image.magick",
+                                                        inputs: [ fixture("animated.gif") ], outputs: [ destination ],
+                                                        payload: { format: "jpg",
+                                                                   operations: { loader: { page: nil }, resize_to_limit: [ 20, 20 ] } })
+
+        assert_predicate failure, :permanent?
+        assert_match "multi-layer", failure.message
+      end
+    end
+  end
+
   def test_combine_options_is_refused
     Cell.boot do |cell|
       with_output do |destination|


### PR DESCRIPTION
## Problem

The image transformers classify the backends' own errors (MiniMagick::Error, MiniMagick::Invalid, Vips::Error) as `unreadable`, but not ImageProcessing::Error — the pipeline's own verdict on an input against the requested transform. Unclassified, it answers `failed`: transient, never recorded against the blob.

Surfaced in HEY production: a 20.9MB multi-layer image requested with `loader: { page: nil }` into a single-layer jpeg destination — ImageProcessing refuses the combination after 17 seconds of decode, the app renders a placeholder with no mark, and the same file spends another full conversion on every future request. The in-process path these operations replaced treated ImageProcessing::Error as permanent, so this is a classification regression for every consuming app.

## Fix

`unreadable ImageProcessing::Error` on MagickOperation and VipsOperation, beside the backend errors it belongs with.

## Test

The production shape exactly: `animated.gif` with `loader: { page: nil }` into `.jpg` answers `unreadable`, permanent, naming "multi-layer". Fails as `failed` without the declaration (verified). The vips pipeline converts that same input happily — it loads page 0 regardless — so the vips declaration stands on principle with no reproducible input shape to pin it; its comment is scoped accordingly.

Suites green: 80 runs / 458 assertions (activestorage), rubocop clean.