### PR TITLE
Bound the cell's OpenMP thread pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ This changelog covers five gems, which release together on the same version:
 
 * `HotCell.describe_cells` no longer warns about a client whose operation the cell does not carry, and `HotCell.clients` is gone with it. The check could not tell a client the application calls from one it merely loaded, so a cell carrying a subset of what a gem ships warned on every boot. A request for an operation a cell does not carry is refused as `unsupported`, naming the operation, and that failure is transient and reaches the application's error reporting. An application that wants a boot check can write one over its own configuration.
 
+#### Fixed
+
+* The installed `Dockerfile` sets `OMP_NUM_THREADS` and `OMP_THREAD_LIMIT`. OpenMP sizes its thread pool from the host's core count, and a container's `cpus` quota is a CFS quota rather than an affinity mask, so libvips and ImageMagick asked a 98-core host for 98 threads however small the cell's share of it was. A thread stack is 8MB of private anonymous memory, which `RLIMIT_DATA` charges, so the pool alone cleared the cell's `memory` limit — and libgomp calls `exit(1)` on the first `pthread_create` it cannot satisfy. Match `OMP_NUM_THREADS` to the container's `cpus`. An upgrade leaves an existing `Dockerfile` alone, so a cell installed before this needs both added by hand and the image rebuilt. `docs/DEPLOYMENT.md` covers why the guard has to be a test rather than a deploy to beta: the failure exists only at production's core count.
+
+### HotCell::Server
+
+#### Fixed
+
+* `Operation#run_tool` carries `OMP_NUM_THREADS` and `OMP_THREAD_LIMIT` from the cell's environment into the environment it writes for a tool. A tool sees only what its operation wrote for it, so the image's bound would otherwise have applied to in-process libvips and to nothing the cell execs.
+
+### ActiveStorage::HotCell::Server
+
+#### Fixed
+
+* `MiniMagick.cli_env` carries the cell's `OMP_NUM_THREADS` and `OMP_THREAD_LIMIT`, so `magick` runs under the image's bound rather than sizing its pool from the host's cores. `MiniMagick.restricted_env` is what had removed them.
+
 
 ## v0.2.0 / 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,11 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 ```
 
+Match the `OMP_NUM_THREADS` the installed `Dockerfile` sets to the container's `cpus` below. OpenMP
+reads the host's core count, which a `cpus` quota does not lower, so an unbounded libvips or ImageMagick
+asks a large host for one 8MB thread stack per core and dies on its own memory limit -- see
+[Bound the OpenMP thread pools](docs/DEPLOYMENT.md#bound-the-openmp-thread-pools).
+
 Build the image from the `hotcell/` directory and deploy it as a second container beside the
 application, on the same host, sharing one volume that holds the sockets. With Kamal, that is one
 accessory per cell:

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
@@ -22,8 +22,14 @@ require "image_processing/mini_magick"
 # is covered too. Note what this is: mini_magick filters the environment it was given, where `run_tool`
 # writes a fresh one. Driving `magick` directly would make it ours, and that is the separate enhancement
 # this class already names.
+#
+# The OpenMP variables come from the cell's environment rather than being named here: the number belongs
+# to the image, which is configured to match the container's CPU quota. Without them the restriction would
+# hand `magick` the pool the image's bound was meant to take away. `run_tool` carries the same pair.
 MiniMagick.restricted_env = true
-MiniMagick.cli_env = { "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8" }
+MiniMagick.cli_env = { "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
+                       "OMP_NUM_THREADS" => ENV["OMP_NUM_THREADS"],
+                       "OMP_THREAD_LIMIT" => ENV["OMP_THREAD_LIMIT"] }.compact
 
 module ActiveStorage
   module HotCell

--- a/activestorage-hotcell-server/test/magick_environment_test.rb
+++ b/activestorage-hotcell-server/test/magick_environment_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "etc"
 
 # Invariant 9: a tool sees only the environment its operation wrote for it. `Operation#run_tool` holds it
 # with `unsetenv_others: true`, and the magick operations do not use it — mini_magick spawns `magick`
@@ -38,7 +39,82 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
     end
   end
 
+  # `magick` sees only the environment mini_magick writes for it, so the image's OpenMP bound has to be
+  # named in `cli_env`; the restriction above is otherwise what takes it away.
+  def test_the_cli_env_carries_the_cells_openmp_bound
+    bound = { "OMP_NUM_THREADS" => "2", "OMP_THREAD_LIMIT" => "8" }
+
+    assert_equal bound, magick_cli_env_under(bound)
+    assert_empty magick_cli_env_under({}), "the cell invented a bound of its own"
+  end
+
+  # mini_magick, rather than our hash: it is unbounded in the gemspec, and a version that stopped merging
+  # `cli_env` would leave the assertion above passing and `magick` unbounded again.
+  def test_mini_magick_hands_the_bound_to_magick
+    skip "ImageMagick is not installed" unless magick_installed?
+    skip "a #{Etc.nprocessors}-core host cannot tell a bounded pool from an unbounded one" if
+      Etc.nprocessors < 4
+
+    assert_operator magick_threads_through_mini_magick("OMP_NUM_THREADS" => "2"), :<,
+                    magick_threads_through_mini_magick({})
+  end
+
+  # The premise: `magick` reads OMP_NUM_THREADS out of the environment it is given, so naming it in
+  # `cli_env` bounds a real pool.
+  def test_magick_reads_an_openmp_bound_out_of_its_environment
+    skip "a #{Etc.nprocessors}-core host cannot tell a bounded pool from an unbounded one" if
+      Etc.nprocessors < 4
+
+    assert_operator magick_thread_resource("OMP_NUM_THREADS" => "2"), :<, magick_thread_resource({})
+  end
+
   private
+    def magick_cli_env_under(environment)
+      JSON.parse in_a_child(environment, <<~RUBY)
+        require "json"
+        require "active_storage/hot_cell/server/magick_operation"
+        puts JSON.dump(MiniMagick.cli_env.slice("OMP_NUM_THREADS", "OMP_THREAD_LIMIT"))
+      RUBY
+    end
+
+    # Through mini_magick's own spawn rather than IO.popen, which is the whole point: what mini_magick
+    # merges into that child is what the assertion is about. Nothing here rescues, so a child that cannot
+    # run fails the test rather than reading as a bound of zero.
+    def magick_threads_through_mini_magick(environment)
+      output = in_a_child(environment, <<~'RUBY')
+        require "active_storage/hot_cell/server/magick_operation"
+        print MiniMagick.convert { |command| command.list "resource" }[/Thread: (\d+)/, 1]
+      RUBY
+
+      Integer(output)
+    end
+
+    # The operation reads the variables at require time, so each case needs its own process. A developer's
+    # own shell may hold either, so the child starts from neither and takes only what the case gives it.
+    def in_a_child(environment, script)
+      environment = { "OMP_NUM_THREADS" => nil, "OMP_THREAD_LIMIT" => nil }.merge(environment)
+      lib = File.expand_path("../lib", __dir__)
+
+      IO.popen([ environment, RbConfig.ruby, "-I", lib, "-r", "bundler/setup", "-e", script ], &:read)
+    end
+
+    # Both sides start from no bound at all: a runner holding one of its own would otherwise compare a
+    # bounded pool against a bounded pool.
+    def magick_installed?
+      system "magick", "-version", out: File::NULL, err: File::NULL
+    rescue Errno::ENOENT
+      false
+    end
+
+    def magick_thread_resource(environment)
+      environment = { "OMP_NUM_THREADS" => nil, "OMP_THREAD_LIMIT" => nil }.merge(environment)
+      output = IO.popen([ environment, "magick", "-list", "resource" ], &:read)
+
+      Integer(output[/Thread: (\d+)/, 1])
+    rescue Errno::ENOENT
+      skip "ImageMagick is not installed"
+    end
+
     def with_refusing_policy_in_the_environment
       Dir.mktmpdir "hotcell-magick-policy" do |directory|
         File.write File.join(directory, "policy.xml"), <<~XML

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -22,6 +22,7 @@ own workload, where this one covers what the values mean.
   * [Performance](#performance)
   * [Security](#security)
   * [General](#general)
+  * [Bound the OpenMP thread pools](#bound-the-openmp-thread-pools)
   * [Sizing the numbers](#sizing-the-numbers)
 - [Cell settings](#cell-settings)
   * [Performance](#performance-1)
@@ -187,7 +188,7 @@ from the README's accessory, not recommendations.
 
 | Flag | Example | Tune it from |
 | --- | --- | --- |
-| `cpus` | `2` | The share of the host this cell may use. Start the cell's `concurrency` at twice this number. |
+| `cpus` | `2` | The share of the host this cell may use. Start the cell's `concurrency` at twice this number, and match the image's `OMP_NUM_THREADS` to it — see "Bound the OpenMP thread pools". |
 | `memory` | `2g` | The cgroup limit, counting every worker and the tmpfs. Size it from `concurrency × peak RSS` plus the tmpfs. Keep it above the cell's `memory`. On a disk-backed scratch there is no tmpfs term — see "Where scratch lives". |
 | `memory-swap` | `2g` | Set it equal to `memory`. Omit it and Docker allows twice `memory` in swap, so the memory limit no longer holds. |
 | `tmpfs` size | `size=512m` | Scratch for all concurrent workers together. It pairs with `file_size × concurrency`. Moving scratch onto disk decouples it from `memory` — see "Where scratch lives". |
@@ -220,6 +221,45 @@ Environment variables. The image sets all of them, so set one only to override i
 | `HOTCELL_WORKSPACE` | a directory under `Dir.tmpdir` | Where each request's directory is made and removed. On the default accessory this is the tmpfs. |
 | `HOTCELL_HEALTH_TIMEOUT` | `5` | Seconds `hotcell-health` waits for an answer before it reports unhealthy. |
 | `HOME` | `/tmp` | Bundler needs one, and the cell's user has no home directory. A worker replaces it with a directory made for the request and removed with it. |
+| `OMP_NUM_THREADS` | `2` | The OpenMP pool size libvips and ImageMagick use. Match it to `cpus`. See "Bound the OpenMP thread pools". |
+| `OMP_THREAD_LIMIT` | `8` | The ceiling on that pool, including a library that raises the count itself. |
+
+### Bound the OpenMP thread pools
+
+**Set `OMP_NUM_THREADS` and `OMP_THREAD_LIMIT` in the image.** The installed `Dockerfile` sets both, and
+on a large host neither is optional: without them a cell dies there. `hotcell:install` leaves an existing
+`Dockerfile` untouched, so add both by hand to a cell installed before this and rebuild its image.
+
+OpenMP sizes its thread pool from the host's core count, and a `cpus:` limit is a CFS quota rather than an
+affinity mask, so it does not lower that count — on a 98-core host libvips and ImageMagick ask for 98
+threads. Each thread stack is 8MB of private anonymous memory, which the cell's `memory` charges as
+`RLIMIT_DATA`: under a 1280MB limit, 96 of those stacks fit and 104 do not. Past that line `pthread_create` returns `EAGAIN`, which libgomp treats as unrecoverable — it writes
+
+```
+libgomp: Thread creation failed: Resource temporarily unavailable
+```
+
+to stderr and calls `exit(1)`. The worker dies before answering, so the caller gets a transient failure and
+the job retries it against a host that fails the same way. This killed 285 Basecamp workers in production
+on 2026-08-31 and forced a rollback.
+
+**Size `OMP_NUM_THREADS` from the container's `cpus`:** the number follows the allocation, not the example
+above. It is a thread count, so round a fractional quota down, and up to 1 below that. `OMP_THREAD_LIMIT` is the backstop against a library that raises the count itself by calling
+`omp_set_num_threads`, which is what ImageMagick does for `MAGICK_THREAD_LIMIT`.
+
+**The cell forwards the bound to the tools it execs.** A tool sees the environment its operation wrote for
+it rather than the worker's own, which is invariant 9, so the image's variables alone would bound
+in-process libvips and nothing else. `Operation#run_tool` and mini_magick both carry the pair from the
+cell's environment.
+
+**A deploy to staging or beta cannot catch a regression here.** The failure exists only at production's
+core count — which is how it reached production. So the guard is a test:
+`hotcell-client/test/install_test.rb` holds the scaffold's variables, and an image you customize needs its
+own.
+
+To verify a built image, write a GIF inside it and count `/proc/self/task` during the write. GIF is the
+cheapest probe: it is the only common output format that quantizes, and quantization is where the threads
+appear. Unbounded, the count tracks the visible cores; bounded, it stays at the limit.
 
 ### Sizing the numbers
 

--- a/examples/gate
+++ b/examples/gate
@@ -59,7 +59,8 @@ SECURE = {
   cap_bound: 0,
   no_new_privs: true,
   uid: 10001,
-  tool_env: %w[ HOME LANG LC_ALL PATH ],
+  tool_env: %w[ HOME LANG LC_ALL OMP_NUM_THREADS OMP_THREAD_LIMIT PATH ],
+  tool_omp: %w[ OMP_NUM_THREADS=2 OMP_THREAD_LIMIT=8 ],
 }.freeze
 
 # The full deployment shape passes.
@@ -82,6 +83,10 @@ end
   "a root filesystem not mounted read-only" => { root_readonly: false },
   "an unreadable root mount" => { root_readonly: nil },
   "a scratch that is not noexec" => { scratch_noexec: false },
+  "an image that sets no OpenMP thread count" => { tool_omp: %w[ OMP_THREAD_LIMIT=8 ] },
+  "an image that sets no OpenMP thread limit" => { tool_omp: %w[ OMP_NUM_THREADS=2 ] },
+  "an OpenMP thread count set to nothing" => { tool_omp: [ "OMP_NUM_THREADS=", "OMP_THREAD_LIMIT=8" ] },
+  "an OpenMP bound the cell could not report" => { tool_omp: nil },
 }.each do |description, override|
   check("the isolation check fails on #{description}") do
     raise "the battery accepted it" unless isolation_raises?(SECURE.merge(override))

--- a/examples/lib/battery.rb
+++ b/examples/lib/battery.rb
@@ -190,8 +190,18 @@ module Examples
         assert result[:uid].to_i.positive?, "the cell runs as root or could not report its uid: #{result[:uid].inspect}"
 
         assert result[:tool_env], "the env tool could not run inside the cell"
-        extra = result[:tool_env] - %w[ HOME LANG LC_ALL PATH ]
+        extra = result[:tool_env] - %w[ HOME LANG LC_ALL OMP_NUM_THREADS OMP_THREAD_LIMIT PATH ]
         assert_equal [], extra, "an exec'd tool sees more than the written environment"
+
+        # The one check here about the image rather than the runtime. An unbounded OpenMP pool takes one
+        # 8MB thread stack per host core, which RLIMIT_DATA charges, so an image that dropped the bound
+        # passes every other check and kills a worker only on a host with the cores to do it. A positive
+        # number, because a variable set to the empty string is present and bounds nothing.
+        omp = Array(result[:tool_omp])
+        assert omp.grep(/\AOMP_NUM_THREADS=[1-9][0-9]*\z/).any?,
+               "the image sets no OpenMP thread count: #{omp.inspect}"
+        assert omp.grep(/\AOMP_THREAD_LIMIT=[1-9][0-9]*\z/).any?,
+               "the image sets no OpenMP thread limit: #{omp.inspect}"
       end
 
       # The other half of the shared group. It lets a cell read an input and write an output, and this is

--- a/examples/operations/isolation.rb
+++ b/examples/operations/isolation.rb
@@ -7,6 +7,9 @@
 # Each answers nil where the platform cannot say (macOS has no /sys and no /proc), so the same file loads
 # in a native development cell; the battery reads that nil as a failed check rather than a pass, so a cell
 # that cannot report a flag never passes for silence.
+#
+# The OpenMP variables come back with their values rather than as names alone: an image that set one to
+# the empty string bounds nothing and would pass a check that only asked whether it was there.
 module Examples
   class Isolation < HotCell::Operation
     operation "example.isolation"
@@ -21,7 +24,8 @@ module Examples
         cap_bound: cap_bound,
         no_new_privs: no_new_privs,
         uid: Process.uid,
-        tool_env: tool.ok? ? tool.out.lines.map { |line| line.split("=", 2).first }.sort : nil }
+        tool_env: tool.ok? ? tool.out.lines.map { |line| line.split("=", 2).first }.sort : nil,
+        tool_omp: tool.ok? ? tool.out.lines.grep(/\AOMP_/).map(&:chomp).sort : nil }
     end
 
     private

--- a/hotcell-client/lib/hot_cell/install/Dockerfile.tt
+++ b/hotcell-client/lib/hot_cell/install/Dockerfile.tt
@@ -30,9 +30,17 @@ RUN mkdir -p /run/hotcell/cell /hotcell/operations && chown -R hotcell:hotcell /
 
 # HOME is /tmp because the cell's user has no home directory, and bundler wants one. A worker replaces
 # it with its slot's home before it serves anything.
+#
+# OpenMP sizes its thread pool from the host's core count, and a `cpus:` quota does not lower it, so an
+# unbounded libvips or ImageMagick asks a 98-core host for 98 threads, each with an 8MB stack.
+# `RLIMIT_DATA` charges those stacks, and libgomp calls `exit(1)` on the first `pthread_create` it cannot satisfy. Match
+# OMP_NUM_THREADS to the container's `cpus:`: the number follows the allocation rather than being 2.
+# OMP_THREAD_LIMIT bounds a library that raises the count itself, which is what ImageMagick does.
 ENV HOME=/tmp \
     BUNDLE_PATH=/hotcell/bundle \
     BUNDLE_WITHOUT=development \
+    OMP_NUM_THREADS=2 \
+    OMP_THREAD_LIMIT=8 \
     HOTCELL_OPERATIONS=/hotcell/operations \
     HOTCELL_DIR=/run/hotcell/cell
 

--- a/hotcell-client/test/install_test.rb
+++ b/hotcell-client/test/install_test.rb
@@ -69,6 +69,20 @@ class InstallTest < HotCellClientTest
     end
   end
 
+  # An unbounded OpenMP pool asks for one 8MB thread stack per host core, which `RLIMIT_DATA` charges, so
+  # a large host kills the cell where a small one only wastes memory. Neither a beta host nor a laptop has
+  # the cores to reproduce that, which is why the guard is a test rather than an environment.
+  def test_install_bounds_the_openmp_thread_pools
+    Dir.mktmpdir do |root|
+      HotCell::Install.call(root, out: StringIO.new)
+
+      dockerfile = File.read(File.join(root, "hotcell", "Dockerfile"))
+
+      assert_match(/^\s*OMP_NUM_THREADS=[1-9]\d*\s*\\?$/, dockerfile)
+      assert_match(/^\s*OMP_THREAD_LIMIT=[1-9]\d*\s*\\?$/, dockerfile)
+    end
+  end
+
   def test_install_leaves_an_existing_file_exactly_as_it_is
     Dir.mktmpdir do |root|
       customized = File.join(root, "hotcell", "Dockerfile")

--- a/hotcell-server/lib/hot_cell/operation.rb
+++ b/hotcell-server/lib/hot_cell/operation.rb
@@ -196,8 +196,12 @@ module HotCell
         kept
       end
 
+      # The OpenMP variables come from the cell's environment rather than being named here: the number
+      # belongs to the image, which is configured to match the container's CPU quota. Without them
+      # `unsetenv_others: true` would hand an exec'd tool the pool the image's bound was meant to take away.
       def tool_environment(overrides)
-        { "HOME" => ENV["HOME"], "PATH" => ENV["PATH"], "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8" }
+        { "HOME" => ENV["HOME"], "PATH" => ENV["PATH"], "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
+          "OMP_NUM_THREADS" => ENV["OMP_NUM_THREADS"], "OMP_THREAD_LIMIT" => ENV["OMP_THREAD_LIMIT"] }
           .merge(overrides.transform_keys(&:to_s))
           .compact
       end

--- a/hotcell-server/test/environment_test.rb
+++ b/hotcell-server/test/environment_test.rb
@@ -53,6 +53,29 @@ class EnvironmentTest < HotCellServerTest
     end
   end
 
+  # An exec'd tool sees only what run_tool wrote for it, so the image's OpenMP bound has to be written
+  # there too, or the shelled-out half of a toolchain — `magick`, `ffmpeg` — keeps an unbounded pool.
+  def test_a_tool_inherits_the_cells_openmp_bound
+    with_openmp_bound do
+      TestCell.boot do |cell|
+        seen = assert_ok(cell.call("test.environment")).result[:seen]
+
+        assert_includes seen, "OMP_NUM_THREADS=2"
+        assert_includes seen, "OMP_THREAD_LIMIT=8"
+      end
+    end
+  end
+
+  def test_a_tool_gets_no_openmp_bound_the_cell_does_not_have
+    without_openmp_bound do
+      TestCell.boot do |cell|
+        seen = assert_ok(cell.call("test.environment")).result[:seen]
+
+        assert_empty seen.grep(/\AOMP_/), "the cell invented a bound of its own"
+      end
+    end
+  end
+
   # capture3 accumulated both streams in full and handed them over at exit, so slicing afterwards bounded
   # only the Strings this method returned. An input that made a tool print 40MB of diagnostics had
   # already cost this worker 40MB of address space — which RLIMIT_DATA charges, arriving as a `memory`
@@ -74,5 +97,22 @@ class EnvironmentTest < HotCellServerTest
       yield
     ensure
       ENV.delete CANARY
+    end
+
+    # The environment a container would have given the cell. A developer's own shell may hold either
+    # variable, so both are restored rather than deleted.
+    def with_openmp_bound(count = "2", limit = "8")
+      original = ENV.slice("OMP_NUM_THREADS", "OMP_THREAD_LIMIT")
+      ENV["OMP_NUM_THREADS"] = count
+      ENV["OMP_THREAD_LIMIT"] = limit
+      yield
+    ensure
+      ENV.delete "OMP_NUM_THREADS"
+      ENV.delete "OMP_THREAD_LIMIT"
+      ENV.update original
+    end
+
+    def without_openmp_bound(&block)
+      with_openmp_bound(nil, nil, &block)
     end
 end


### PR DESCRIPTION
An image that set neither `OMP_NUM_THREADS` nor `OMP_THREAD_LIMIT` let libvips and ImageMagick size their pool from the host's core count, because a container's `cpus` is a CFS quota rather than an affinity mask. A thread stack is 8MB of private anonymous memory that `RLIMIT_DATA` charges, so on a large host the pool alone exceeded a worker's memory limit, and libgomp calls `exit(1)` on the first `pthread_create` it cannot satisfy. That killed 285 Basecamp workers in production on 2026-08-31.

Set both in the installed `Dockerfile`, and carry them into the environment written for an exec'd tool — `Operation#run_tool` and `MiniMagick.cli_env` — where `unsetenv_others` and `MiniMagick.restricted_env` had been removing them. The conformance battery now requires a positive value for each, and `docs/DEPLOYMENT.md` covers sizing them and why the guard has to be a test rather than a deploy to beta.

ref: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10256988095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
