### PR TITLE
Capture what a worker writes to fd 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ This changelog covers five gems, which release together on the same version:
 
 * The installed `Dockerfile` applies Debian's pending security patches with an `apt-get upgrade` after the `FROM`. `docker build --pull` takes the newest base tag, but the tag itself can sit behind an advisory that is already in `trixie-security` until [docker-library/ruby](https://github.com/docker-library/ruby) rebuilds it, so a clean build shipped a fixable High that no rebuild of the cell could clear. Upgrading during the build makes the image's patch level its own rather than upstream's release cadence, and it stops the class rather than the one advisory. An upgrade leaves an existing `Dockerfile` alone, so a cell installed before this needs the line added by hand and the image rebuilt.
 
+### HotCell::Core and HotCell::Server
+
+#### Added
+
+* A worker's file descriptor 2 is a pipe to the supervisor, which drains it as it runs and attaches the last 512 bytes to the `worker.killed` that reports its death, as `hotcell.stderr`, and to the failure the caller receives, as `stderr`. A C library that calls `exit()` raises nothing, so `worker.crashed` is never written and the connection carries a bare `crashed`; the account of what happened was on fd 2, which goes to the container runtime's log driver, where the fleet's collector drops complete non-JSON lines at ingest. `libgomp: Thread creation failed: Resource temporarily unavailable` is the line this exists for. The field is there to make a death legible, not to ship a cell's stderr anywhere, so a worker that warns and then answers normally reports nothing. The capture is best effort and untrusted: fd 2 stays non-blocking so that a warning written from inside libvips can never wait on the supervisor's scheduling, and everything a worker spawned inherits the descriptor. `docs/LOGS.md` states what the field is and is not.
+
 ### HotCell::Server
 
 #### Fixed

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -243,6 +243,10 @@ to stderr and calls `exit(1)`. The worker dies before answering, so the caller g
 the job retries it against a host that fails the same way. This killed 285 Basecamp workers in production
 on 2026-08-31 and forced a rollback.
 
+That line reaches a log now: the supervisor captures what a worker writes to fd 2 and attaches its tail to
+the `worker.killed` that reports its death, as `hotcell.stderr`, and to the failure the caller receives. See
+`docs/LOGS.md`.
+
 **Size `OMP_NUM_THREADS` from the container's `cpus`:** the number follows the allocation, not the example
 above. It is a thread count, so round a fractional quota down, and up to 1 below that. `OMP_THREAD_LIMIT` is the backstop against a library that raises the count itself by calling
 `omp_set_num_threads`, which is what ImageMagick does for `MAGICK_THREAD_LIMIT`.

--- a/docs/LOGS.md
+++ b/docs/LOGS.md
@@ -48,6 +48,7 @@ Everything else is ours and sits under `hotcell.*`:
 | `hotcell.timing` | object | A request's phase timings: `queued_ms`, `perform_ms`, and any measured phases. |
 | `hotcell.deadline_s` / `hotcell.grace_s` / `hotcell.waited_s` | number | The limit that was hit, on the event that reports hitting it. |
 | `hotcell.path` | string | The file the cell could not verify, on `cell.ptrace_scope_unknown`. |
+| `hotcell.stderr` | string | The tail of what a dying worker wrote to file descriptor 2, at most 512 bytes. On `worker.killed` only, and absent when it wrote nothing. See below. |
 
 ## Events
 
@@ -62,7 +63,7 @@ Everything else is ours and sits under `hotcell.*`:
 | `worker.forked` | INFO | `hotcell.slot` |
 | `worker.reaped` | INFO | `hotcell.slot`, `hotcell.served`, `hotcell.signal`, `process.exit_code` |
 | `worker.crashed` | ERROR | `hotcell.slot`, `error.type`, `error.message` |
-| `worker.killed` | WARN | `hotcell.slot`, `hotcell.cause`, `hotcell.signal`, `event.duration.ms` |
+| `worker.killed` | WARN | `hotcell.slot`, `hotcell.cause`, `hotcell.signal`, `event.duration.ms`, `hotcell.stderr` |
 | `worker.deadline` | WARN | `hotcell.slot`, `hotcell.deadline_s` |
 | `worker.lingered` | WARN | `hotcell.slot`, `hotcell.grace_s` |
 | `worker.unforkable` | ERROR | `hotcell.slot`, `error.type`, `error.message` |
@@ -73,6 +74,41 @@ Everything else is ours and sits under `hotcell.*`:
 | `slot.uncleaned` | WARN | `hotcell.slot`, `hotcell.home`, `message` (boot sweep only) |
 | `slot.undiscarded` | WARN | `hotcell.slot`, `hotcell.home` |
 | `slot.unswept` | WARN | `hotcell.slot`, `hotcell.home` |
+
+## What a worker wrote to fd 2
+
+A worker's fd 2 is a pipe to the supervisor, which drains it as the worker runs and attaches the tail to
+the `worker.killed` reporting its death. The same text rides the failure the caller receives, so an
+application logs `killed: crashed (libgomp: ...)` rather than a bare `crashed`.
+
+It exists for the death nothing else in a cell can describe. `HotCell::Worker#run` rescues `Exception`, so
+a worker that died with no `worker.crashed` line probably died without Ruby raising at all: a C library
+called `exit()`, and said why on fd 2.
+
+```
+libgomp: Thread creation failed: Resource temporarily unavailable
+```
+
+**The text is not evidence — it establishes neither who wrote it nor which request it belongs to**, the
+caveat `hotcell.signal` and `hotcell.cause` already carry. It comes from the one process in a cell that
+runs untrusted code, over an unauthenticated channel: everything a worker spawned inherits fd 2, so a tool
+can write long after the request it belongs to finished, and a sibling worker can open `/proc/<pid>/fd/2`
+and write whatever it likes, since workers share a uid and `kernel.yama.ptrace_scope` protects memory
+rather than descriptors. The supervisor clears the buffer at each dispatch, which keeps an old warning off
+an unrelated death in the ordinary case. It is not a boundary.
+
+**The capture is best effort, because fd 2 is non-blocking.** A C library writing to a full pipe gets `EAGAIN`
+and loses the line, and a fatal handler cannot retry — it writes once and calls `exit()`. That costs nothing
+in the case this exists for, where libgomp's one short line meets an empty pipe. What it loses is the fatal
+from a decoder that had already filled the pipe with warnings, where the field reports the tail of those
+warnings instead. The alternative was refused: a blocking fd 2 would make a warning written from inside
+libvips wait on the supervisor's scheduling, in a C call Ruby cannot interrupt, and that wait is nearest
+exactly when the host is under pressure.
+
+**Only a death is reported.** A worker that warns and then answers normally leaves no field behind, on any
+event. So a tool that dies while its worker survives is not described here, and a cell's stderr no longer
+reaches the container's log driver at all — which loses nothing, because the fleet's OTel collector drops
+complete non-JSON lines at ingest.
 
 ## Examples
 

--- a/hotcell-core/lib/hot_cell/failure.rb
+++ b/hotcell-core/lib/hot_cell/failure.rb
@@ -15,19 +15,24 @@ module HotCell
   class Failure
     MAX_MESSAGE_BYTES = 512
 
-    attr_reader :code, :message, :error_class, :cause, :signal
+    attr_reader :code, :message, :error_class, :cause, :signal, :stderr
 
-    # Every field is sanitized, not only the message. All five arrive from the wire on the client side, so
-    # all five carry whatever the peer put there — and they travel further than the message does, into
+    # Every field is sanitized, not only the message. All of them arrive from the wire on the client side,
+    # so all of them carry whatever the peer put there — and they travel further than the message does, into
     # `to_s`, into the `perform.hot_cell` event, and into whatever a subscriber writes down. `code` in
-    # particular is the field applications store. Scrubbing one and not the other four left the same
-    # poisoned row the scrub exists to prevent, reachable through a different key.
-    def initialize(code:, permanent: nil, message: nil, error_class: nil, cause: nil, signal: nil)
+    # particular is the field applications store. Scrubbing one and not the rest left the same poisoned row
+    # the scrub exists to prevent, reachable through a different key.
+    def initialize(code:, permanent: nil, message: nil, error_class: nil, cause: nil, signal: nil,
+                   stderr: nil)
       @code = self.class.sanitize(code).to_s
       @cause = self.class.sanitize(cause)
       @signal = self.class.sanitize(signal)
       @error_class = self.class.sanitize(error_class)
       @message = self.class.sanitize(message)
+
+      # The tail, because this is a transcript and its last line is the one that ended the request. Every
+      # other field is one message, where the head is what matters.
+      @stderr = self.class.sanitize(stderr, keep: :tail)
       @permanent = permanent.nil? ? Codes.permanent?(@code, cause: @cause) : permanent
     end
 
@@ -40,11 +45,15 @@ module HotCell
     # `permanent` is the exception and survives, because compact drops only nil.
     def to_h
       { code: code, permanent: permanent? }
-        .merge(cause: cause, signal: signal, class: error_class, message: message).compact
+        .merge(cause: cause, signal: signal, class: error_class, message: message, stderr: stderr).compact
     end
 
+    # `one_line` rather than raw interpolation: `to_s` becomes the exception message an application logs, and
+    # a transcript ends in a newline — so a peer that put newlines in one writes extra lines into that log.
+    # The attribute keeps the raw text.
     def to_s
-      [ code, cause, error_class, message ].compact.join(": ")
+      text = [ code, cause, error_class, message ].compact.join(": ")
+      stderr ? "#{text} (#{self.class.one_line(stderr)})" : text
     end
 
     class << self
@@ -73,7 +82,7 @@ module HotCell
         end
 
         new code: wire[:code], permanent: permanent, cause: wire[:cause], signal: wire[:signal],
-            error_class: wire[:class], message: wire[:message]
+            error_class: wire[:class], message: wire[:message], stderr: wire[:stderr]
       end
 
       # For a message that is about to be written as one line of a log. `sanitize` leaves CR and LF alone,
@@ -84,11 +93,20 @@ module HotCell
         sanitize(text)&.gsub(/[[:cntrl:]]/) { |character| character.dump[1..-2] }
       end
 
-      def sanitize(message)
+      # `keep: :tail` is for a captured stream rather than a message, and it is load-bearing on `from_wire`:
+      # a cell this client does not trust can fill that field to the response limit, and head-truncating
+      # there hands the caller the noise a decoder printed first instead of the fatal that ended it.
+      def sanitize(message, keep: :head)
         return nil if message.nil?
 
-        String(message).dup.force_encoding(Encoding::UTF_8)
-          .scrub("").byteslice(0, MAX_MESSAGE_BYTES).scrub("")
+        text = String(message).dup.force_encoding(Encoding::UTF_8).scrub("")
+        text = if keep == :tail && text.bytesize > MAX_MESSAGE_BYTES
+          text.byteslice(text.bytesize - MAX_MESSAGE_BYTES, MAX_MESSAGE_BYTES)
+        else
+          text.byteslice(0, MAX_MESSAGE_BYTES)
+        end
+
+        text.scrub("")
       end
     end
   end

--- a/hotcell-core/test/response_test.rb
+++ b/hotcell-core/test/response_test.rb
@@ -112,6 +112,29 @@ class ResponseTest < HotCellTest
     assert_predicate failure.to_s, :valid_encoding?
   end
 
+  # `to_s` becomes the exception message an application logs, and a captured transcript ends in a newline.
+  # Interpolated raw, a peer writes extra lines into that log — formatted and indented like the real ones.
+  def test_to_s_is_one_physical_line_even_with_a_captured_transcript
+    failure = HotCell::Failure.new(code: "killed", cause: "crashed",
+                                   stderr: "\nlibgomp: Thread creation failed\n")
+
+    assert_equal 1, failure.to_s.lines.size
+    assert_equal %(killed: crashed (\\nlibgomp: Thread creation failed\\n)), failure.to_s
+    assert_equal "\nlibgomp: Thread creation failed\n", failure.stderr
+  end
+
+  # The cell trims to the tail before it sends, but this is the call site where that cannot be assumed: the
+  # field arrives from a cell the client does not trust, on a line that may carry up to MAX_RESPONSE_BYTES.
+  # Head-truncating here hands the caller the noise a decoder printed first instead of the fatal that ended
+  # the request.
+  def test_from_wire_keeps_the_tail_of_an_oversized_stderr
+    fatal = "libgomp: Thread creation failed\n"
+    failure = HotCell::Failure.from_wire(code: "killed", stderr: ("noise\n" * 5000) + fatal)
+
+    assert_equal HotCell::Failure::MAX_MESSAGE_BYTES, failure.stderr.bytesize
+    assert failure.stderr.end_with?(fatal), "expected the tail and got #{failure.stderr.inspect}"
+  end
+
   def test_a_response_that_is_not_an_object
     assert_raises(HotCell::MessageError) { HotCell::Response.parse("[]\n") }
   end

--- a/hotcell-server/lib/hot_cell/supervisor.rb
+++ b/hotcell-server/lib/hot_cell/supervisor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "socket"
+require "fcntl"
 require "fileutils"
 require "tmpdir"
 
@@ -21,12 +22,31 @@ module HotCell
     # `busy?` and the supervisor assigning the four fields `busy?` is computed from are the same fact. Spread
     # across the caller, a new field is one the next transition forgets to clear.
     Child = Struct.new(:slot, :pid, :control, :connection, :dispatched_at, :deadline, :served, :killed_for,
-                       :retired_at, :buffer, keyword_init: true) do
-      def self.build(slot:, pid:, control:, deadline:)
-        new slot: slot, pid: pid, control: control, deadline: deadline, served: 0, buffer: "".b
+                       :retired_at, :buffer, :stderr, :captured, keyword_init: true) do
+      def self.build(slot:, pid:, control:, deadline:, stderr: nil)
+        new slot: slot, pid: pid, control: control, deadline: deadline, served: 0, buffer: "".b,
+            stderr: stderr, captured: "".b
+      end
+
+      # Keeps the last MAX_MESSAGE_BYTES rather than the first, because the line that ended the request is
+      # the last one written. Trimmed on every read, so a worker that never stops printing costs no more
+      # than that.
+      def capture_stderr(chunk)
+        captured << chunk
+        excess = captured.bytesize - Failure::MAX_MESSAGE_BYTES
+        captured.slice! 0, excess if excess.positive?
+      end
+
+      # A silent worker gets no field at all: `Log#document` does not compact the hotcell namespace, so a nil
+      # would put `"stderr":null` on every death a cell reports.
+      def stderr_field
+        captured.empty? ? {} : { stderr: Failure.sanitize(captured, keep: :tail) }
       end
 
       def dispatched(connection, deadline, at:)
+        # An earlier request's warning is not this request's death. Not a boundary, though: a descendant
+        # holding fd 2 writes whenever it likes, and a sibling can open /proc/<pid>/fd/2 and write there too.
+        captured.clear
         self.connection = connection
         self.dispatched_at = at
         self.deadline = deadline
@@ -105,6 +125,12 @@ module HotCell
     # far above any real scrape rate rather than as a throttle.
     CONTROL_BACKLOG = 64
 
+    # What one pass reads off a worker's fd 2, and how many reads the reap's final drain gets. Sized to
+    # clear a full pipe rather than to bound memory — `Child#capture_stderr` does that — so reading further
+    # would only mean a fresher tail.
+    STDERR_READ_BYTES = 16 * 1024
+    STDERR_FINAL_READS = 8
+
     attr_reader :configuration, :counters, :log, :directory, :workspace
 
     def initialize(directory:, workspace: nil, configuration: HotCell.configuration, log: Log.new,
@@ -163,6 +189,7 @@ module HotCell
       def sources
         [ @signals ].tap do |list|
           list.concat @children.each_value.map { |child| child.control.socket }.reject(&:closed?)
+          list.concat @children.each_value.filter_map(&:stderr).reject(&:closed?)
           list.concat @control_pending.map { |pending| pending.connection.socket }.reject(&:closed?)
           list.push @work, @control unless @stopping
         end
@@ -187,8 +214,13 @@ module HotCell
         when @work then accept_work
         when @control then accept_control
         else
-          pending = pending_control(source)
-          pending ? read_control(pending) : child_reported(source)
+          if (pending = pending_control(source))
+            read_control pending
+          elsif (child = child_writing_stderr(source))
+            drain_stderr child
+          else
+            child_reported source
+          end
         end
       end
 
@@ -378,34 +410,38 @@ module HotCell
         number = free_slot or return nil
         slot = Slot.build(workspace, number)
         supervisor_side, worker_side = UNIXSocket.pair(:STREAM)
+        stderr_reader, stderr_writer = IO.pipe
 
         # A fork that fails is a host under pressure, not a reason to stop serving. The request stays queued
         # and is either dispatched on a later pass or answered `capacity` when its wait runs out.
         pid = begin
           fork do
-            become_worker supervisor_side
+            become_worker supervisor_side, stderr_reader, stderr_writer
             Worker.new(slot: slot, configuration: configuration, control: Connection.new(worker_side),
                        log: log).run
           end
         rescue SystemCallError => error
           log.write "worker.unforkable", slot: number, error: error.class.name, message: error.message
-          supervisor_side.close
-          worker_side.close
+          [ supervisor_side, worker_side, stderr_reader, stderr_writer ].each(&:close)
           return nil
         end
 
+        # The write end goes now rather than at the reap. Held here, the pipe never reports end of stream,
+        # `sources` keeps a dead worker's read end forever, and a worker that said nothing is
+        # indistinguishable from one that has not finished saying it.
         worker_side.close
+        stderr_writer.close
         log.write "worker.forked", pid: pid, slot: number
 
         @children[number] = Child.build(slot: slot, pid: pid, control: Connection.new(supervisor_side),
-                                        deadline: configuration.limits.deadline)
+                                        deadline: configuration.limits.deadline, stderr: stderr_reader)
       end
 
       # Everything the supervisor holds and the worker must not: the listener, the signal pipe, the other
       # children's control sockets, and every connection the supervisor is still holding for somebody else.
       # The connection this worker is about to serve arrives over SCM_RIGHTS a moment from now, so closing
       # the inherited copy here costs nothing and stops it lingering for the worker's whole life.
-      def become_worker(supervisor_side)
+      def become_worker(supervisor_side, stderr_reader, stderr_writer)
         [ "CHLD", "INT", "TERM" ].each { |signal| trap signal, "DEFAULT" }
 
         # Its own process group, so the deadline reaches the tools this request started rather than only the
@@ -438,9 +474,66 @@ module HotCell
         @children.each_value do |child|
           child.control.close
           child.connection&.close
+          child.stderr&.close
         end
         @queue.each { |(connection, _)| connection.close }
         @control_pending.each { |pending| pending.connection.close }
+
+        # fd 2 becomes the pipe, and it stays non-blocking. `IO.pipe` already returns both ends O_NONBLOCK
+        # and `reopen` is a dup2, which shares the file description — so the flag would ride along on its
+        # own. It is set here anyway, because a decision this load-bearing should be in the code rather than
+        # only in a comment, and because it then survives a Ruby that stops handing out non-blocking pipes.
+        #
+        # A blocking fd 2 would put backpressure into the image-processing path, which was never designed
+        # for it: a warning written from inside libvips is a `write(2)` in a C call Ruby cannot interrupt, so
+        # the conversion would wait on the supervisor's scheduling — nearest exactly when the host is under
+        # pressure and the supervisor is scheduled least. That trade is refused; the conversion path must
+        # never wait on the supervisor. What non-blocking loses instead is in docs/LOGS.md, and a test pins
+        # the flag so that a well-meaning fix has to argue with it.
+        stderr_reader.close
+        stderr_writer.fcntl Fcntl::F_SETFL, stderr_writer.fcntl(Fcntl::F_GETFL) | Fcntl::O_NONBLOCK
+        $stderr.reopen stderr_writer
+        stderr_writer.close
+      end
+
+      # One bounded read per pass, never a loop until the pipe is empty: this runs inside the loop that
+      # enforces every request's deadline, and the peer is a worker that can print as fast as it likes.
+      #
+      # End of stream closes the read end. It has to: an EOF pipe is permanently readable, so leaving it in
+      # `sources` turns the run loop into a spin between the worker's exit and its reap.
+      def drain_stderr(child)
+        chunk = begin
+          child.stderr.read_nonblock(STDERR_READ_BYTES, exception: false)
+        rescue SystemCallError
+          nil
+        end
+        return if chunk == :wait_readable
+        return child.stderr.close if chunk.nil?
+
+        child.capture_stderr chunk
+      end
+
+      # A worker's last line sits in the pipe after the process is gone, so the reap reads once more — and
+      # under a flat bound rather than to end of stream. End of stream never arrives while a descendant
+      # holds the write end, and "until the pipe is momentarily empty" terminates only by winning a race
+      # against whoever is writing.
+      def drain_stderr_after_exit(child)
+        STDERR_FINAL_READS.times do
+          break if child.stderr.nil? || child.stderr.closed?
+
+          chunk = begin
+            child.stderr.read_nonblock(STDERR_READ_BYTES, exception: false)
+          rescue SystemCallError
+            nil
+          end
+          break if chunk.nil? || chunk == :wait_readable
+
+          child.capture_stderr chunk
+        end
+      end
+
+      def child_writing_stderr(source)
+        @children.each_value.find { |child| child.stderr.equal?(source) }
       end
 
       # Buffered and non-blocking, for the same reason read_control is, and more so: readability means a byte
@@ -699,11 +792,19 @@ module HotCell
             child_reported child.control.socket
           end
 
+          # Sweep before the last drain, not after. fd 2 is never close-on-exec, so everything this worker
+          # spawned holds the write end too — swept first, what those wrote is waiting to be read rather
+          # than arriving after the last read. The sweep does not make the pipe quiet: SIGKILL is
+          # asynchronous, and a `setsid` descendant is deliberately never reached, so its final bytes are
+          # best effort like everything else here.
           sweep_group child
+          drain_stderr_after_exit child
+
           @children.delete child.slot.number
           answer_for child, status
           discard child
           child.control.close
+          child.stderr&.close
 
           log.write "worker.reaped", pid: pid, slot: child.slot.number, served: child.served,
                                      signal: signal_name(status), exit_code: status.exitstatus
@@ -740,11 +841,17 @@ module HotCell
         counters.record Codes::KILLED
         counters.record_kill cause
 
-        log.write "worker.killed", pid: child.pid, slot: child.slot.number, cause: cause,
-                                   signal: signal_name(status), duration_ms: Clock.ms_since(child.dispatched_at)
+        captured = child.stderr_field
 
+        log.write "worker.killed", pid: child.pid, slot: child.slot.number, cause: cause,
+                                   signal: signal_name(status), duration_ms: Clock.ms_since(child.dispatched_at),
+                                   **captured
+
+        # The capture rides the verdict as well as the log line, so an application logs
+        # `killed: crashed (libgomp: ...)` rather than a bare `crashed`. Additive on the wire: `from_wire`
+        # reads named keys, so an old client ignores the field and a new one against an old cell meets nil.
         answer child.connection,
-               Failure.new(code: Codes::KILLED, cause: cause, signal: signal_name(status)),
+               Failure.new(code: Codes::KILLED, cause: cause, signal: signal_name(status), **captured),
                timing: { perform_ms: Clock.ms_since(child.dispatched_at) }
       end
 

--- a/hotcell-server/lib/hot_cell/test_operations.rb
+++ b/hotcell-server/lib/hot_cell/test_operations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "digest"
+require "fcntl"
 require "fileutils"
 
 # Fixture operations, so the whole surface can be exercised in milliseconds, with no tool installed and no
@@ -459,6 +460,58 @@ module HotCell
         sleep seconds
 
         { slept: seconds, pid: Process.pid }
+      end
+    end
+
+    # Writes to fd 2 and then either dies the way a C library does — `exit()` with no Ruby exception, so
+    # there is no `worker.crashed` line and nothing on the connection — or returns normally, which is the
+    # warning a cell deliberately does not report. `noise:` goes out before `text:`, so a test can ask which
+    # end of an oversized transcript was kept.
+    class StderrWriter < HotCell::Operation
+      operation "test.stderr_writer"
+
+      def perform(_inputs, _outputs, text:, noise: 0, fatal: false)
+        $stderr.write "noise\n" * noise
+        $stderr.write text
+        $stderr.flush
+        exit! 1 if fatal
+
+        { wrote: text.bytesize }
+      end
+    end
+
+    # Bytes that are not valid UTF-8, which a payload cannot carry — so this is a fixture rather than an
+    # argument to StderrWriter. A decoder writing a filename out of a hostile file is where these come from.
+    class GarbledStderr < HotCell::Operation
+      operation "test.garbled_stderr"
+
+      def perform(_inputs, _outputs)
+        $stderr.write "libgomp: \xFF\xFE failed\n".b
+        $stderr.flush
+        exit! 1
+      end
+    end
+
+    # Reports whether fd 2 is non-blocking, which is the load-bearing decision behind the capture: a
+    # blocking fd 2 would put the supervisor's scheduling in the middle of a libvips `write(2)`.
+    class StderrFlags < HotCell::Operation
+      operation "test.stderr_flags"
+
+      def perform(_inputs, _outputs)
+        { nonblock: ($stderr.fcntl(Fcntl::F_GETFL) & Fcntl::O_NONBLOCK).positive? }
+      end
+    end
+
+    # A tool that keeps writing to fd 2 after the worker itself is gone. fd 2 is never close-on-exec, so
+    # everything a worker spawned holds the write end, and the pipe reports no end of stream until the
+    # reap's group sweep kills them.
+    class StderrDescendant < HotCell::Operation
+      operation "test.stderr_descendant"
+
+      def perform(_inputs, _outputs)
+        spawn "sh", "-c", "while :; do echo from the descendant >&2; done"
+        sleep 0.5
+        exit! 1
       end
     end
   end

--- a/hotcell-server/test/worker_stderr_test.rb
+++ b/hotcell-server/test/worker_stderr_test.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# What a worker writes to fd 2, and why it has to reach a log line at all.
+#
+# A C library that calls `exit()` raises nothing, so `Worker#run`'s rescue never sees it, the connection
+# carries a bare `crashed`, and the only account of what happened is on fd 2. In production that stream goes
+# to the container runtime's log driver, where the fleet's collector drops complete non-JSON lines — so a
+# sandbox whose whole job is decoding hostile bytes had one output channel that reached nobody.
+#
+# Every assertion here is on the tail rather than on the whole capture, because a worker is not silent on
+# every platform: off Linux, `Limits.memory_unenforceable!` warns each worker that RLIMIT_DATA cannot be
+# set, and that line is on fd 2 ahead of whatever the test wrote.
+class WorkerStderrTest < HotCellServerTest
+  FATAL = "libgomp: Thread creation failed: Resource temporarily unavailable\n"
+
+  def test_a_line_written_before_a_fatal_exit_arrives_on_worker_killed
+    TestCell.boot(concurrency: 1) do |cell|
+      failure = assert_failed "killed", write_stderr(cell, FATAL, fatal: true), cause: "crashed"
+
+      assert_tail FATAL, killed(cell).dig(:hotcell, :stderr)
+      assert_tail FATAL, failure.stderr
+    end
+  end
+
+  def test_bytes_that_are_not_valid_utf8_are_scrubbed_rather_than_passed_through
+    TestCell.boot(concurrency: 1) do |cell|
+      assert_failed "killed", cell.call("test.garbled_stderr", timeout: 20), cause: "crashed"
+
+      captured = killed(cell).dig(:hotcell, :stderr)
+
+      assert_predicate captured, :valid_encoding?
+      assert_tail "libgomp:  failed\n", captured
+    end
+  end
+
+  # The tail rather than the head, asserted by the last line being present: a transcript's fatal is at the
+  # end, and head-keeping truncation passes any assertion that only checks the length.
+  def test_an_oversized_transcript_is_truncated_to_its_tail
+    TestCell.boot(concurrency: 1) do |cell|
+      assert_failed "killed", write_stderr(cell, FATAL, noise: 20_000, fatal: true), cause: "crashed"
+
+      captured = killed(cell).dig(:hotcell, :stderr)
+
+      assert_tail FATAL, captured
+      assert_operator captured.bytesize, :<=, HotCell::Failure::MAX_MESSAGE_BYTES
+    end
+  end
+
+  # No field at all rather than a null. `Log#document` does not compact the hotcell namespace, so a nil here
+  # would put `"stderr":null` on every death a cell reports. Asserted on the buffer rather than through a
+  # cell because this has to hold on every platform, and off Linux no worker is silent.
+  def test_a_child_that_captured_nothing_contributes_no_field
+    assert_empty build_child(stderr: nil).stderr_field
+  end
+
+  def test_a_worker_that_writes_nothing_produces_no_field
+    skip "a worker warns that RLIMIT_DATA is not settable off Linux" unless RUBY_PLATFORM.include?("linux")
+
+    TestCell.boot(concurrency: 1, deadline: 0.3) do |cell|
+      assert_failed "killed", cell.call("test.uninterruptible", timeout: 20), cause: "deadline"
+
+      refute killed(cell).fetch(:hotcell).key?(:stderr),
+             "expected no stderr field for a worker that said nothing"
+    end
+  end
+
+  # A warning is not a death, and the field exists to make a death legible rather than to ship a cell's
+  # stderr anywhere. So a worker that warns and then answers normally reports nothing, and its `worker.reaped`
+  # carries no capture — which is also what keeps a chatty library off every reap in the fleet.
+  def test_a_worker_that_warns_and_then_succeeds_reports_nothing
+    TestCell.boot(concurrency: 1) do |cell|
+      assert_ok write_stderr(cell, "vips warning: ignoring ICC profile\n")
+
+      wait_until(what: "the worker to be reaped") { cell.log_events("worker.reaped").any? }
+
+      refute cell.log_events("worker.reaped").first.fetch(:hotcell).key?(:stderr)
+      assert_empty cell.log_events("worker.killed")
+    end
+  end
+
+  # The clear at dispatch, from the direction that matters: a warning the worker survived must not be
+  # attached to a later request's death. Needs a reused worker, which the default configuration never
+  # produces.
+  def test_a_warning_from_an_earlier_request_does_not_reach_a_later_requests_death
+    TestCell.boot(concurrency: 1, max_requests_per_worker: 2) do |cell|
+      assert_ok write_stderr(cell, "vips warning: ignoring ICC profile\n")
+      assert_failed "killed", write_stderr(cell, "", fatal: true), cause: "crashed"
+
+      refute_includes killed(cell).dig(:hotcell, :stderr).to_s, "vips warning",
+                      "the earlier request's warning was attached to this one's death"
+    end
+  end
+
+  # A leaked pipe end per fork is a descriptor the supervisor never gets back, and it surfaces as EMFILE
+  # under churn rather than anywhere near the code that caused it. Counted in the supervisor's own process,
+  # which is why this needs procfs.
+  #
+  # A ceiling rather than an equality, and the baseline is taken before the first request: a leak only ever
+  # pushes the count up, while an unreferenced IO the supervisor has finished with is closed whenever its
+  # process next collects, so the count legitimately falls. Asserting equality against a post-request
+  # baseline failed on Ruby 4.0 with two descriptors fewer than it started with.
+  def test_worker_churn_leaves_no_descriptors_behind_in_the_supervisor
+    TestCell.boot(concurrency: 1) do |cell|
+      pid = cell.log_events("cell.boot").first.dig(:process, :pid)
+      booted = supervisor_descriptors(pid)
+
+      5.times { assert_ok cell.call("test.echo") }
+      wait_until(what: "every worker to be reaped") { cell.log_events("worker.reaped").size == 5 }
+
+      assert_operator supervisor_descriptors(pid), :<=, booted,
+                      "the supervisor kept descriptors from the workers it forked"
+    end
+  end
+
+  # Pins the decision `Supervisor#become_worker` records, rather than the plumbing. That code sets the flag
+  # explicitly and `IO.pipe` would supply it anyway, so this asserts the property the two of them exist to
+  # guarantee: whatever a later edit does to either, a conversion must never wait on the supervisor.
+  def test_a_workers_fd_2_is_non_blocking
+    TestCell.boot(concurrency: 1) do |cell|
+      assert_equal({ nonblock: true }, assert_ok(cell.call("test.stderr_flags")).result)
+    end
+  end
+
+  # Bounded, because "until end of stream" never arrives while a descendant holds the write end, and
+  # "until the pipe is momentarily empty" terminates only by winning a race against whoever is writing.
+  # Driven against a temp file: how much a pipe or a socketpair buffers is platform-dependent, and this
+  # suite runs on macOS too.
+  def test_the_final_drain_after_exit_stops_at_its_bound
+    budget = HotCell::Supervisor::STDERR_READ_BYTES * HotCell::Supervisor::STDERR_FINAL_READS
+
+    with_file do |path|
+      File.binwrite path, "x" * (budget * 2)
+
+      File.open(path, "rb") do |source|
+        child = build_child stderr: source
+        supervisor.send :drain_stderr_after_exit, child
+
+        assert_equal budget, source.pos, "expected the drain to stop at its bound"
+        assert_operator File.size(path), :>, source.pos
+      end
+    end
+  end
+
+  # The sweep-then-drain path with something still writing. It does **not** catch an unbounded drain: the
+  # supervisor wins that race in practice, which is why the bound is asserted directly above.
+  def test_a_descendant_still_writing_at_reap_does_not_stop_the_cell_answering
+    TestCell.boot(concurrency: 1) do |cell|
+      assert_failed "killed", cell.call("test.stderr_descendant", timeout: 20), cause: "crashed"
+
+      assert_includes killed(cell).dig(:hotcell, :stderr).to_s, "from the descendant"
+    end
+  end
+
+  private
+    def supervisor_descriptors(pid)
+      skip "counting another process's descriptors needs procfs" unless File.directory?("/proc/#{pid}/fd")
+
+      Dir.children("/proc/#{pid}/fd").size
+    end
+
+    def assert_tail(expected, captured)
+      assert captured&.end_with?(expected), "expected a capture ending in #{expected.inspect} " \
+                                            "and got #{captured.inspect}"
+    end
+
+    def write_stderr(cell, text, noise: 0, fatal: false)
+      cell.call "test.stderr_writer", payload: { text: text, noise: noise, fatal: fatal }, timeout: 20
+    end
+
+    def killed(cell)
+      wait_for_event(cell, "worker.killed").first or flunk "the cell never wrote worker.killed"
+    end
+
+    def supervisor
+      HotCell::Supervisor.new directory: Dir.mktmpdir("hotcell-stderr"), log: HotCell::Log.null
+    end
+
+    def build_child(stderr:)
+      HotCell::Supervisor::Child.build slot: HotCell::Slot.build(Dir.mktmpdir("hotcell-slot"), 0),
+                                       pid: Process.pid, control: HotCell::Connection.new(UNIXSocket.pair.first),
+                                       deadline: 30, stderr: stderr
+    end
+end


### PR DESCRIPTION
285 Basecamp workers died with `cause=crashed` on 2026-08-31 and no `worker.crashed` line: a C library had called `exit()`, and the account of it — `libgomp: Thread creation failed: Resource temporarily unavailable` — was on fd 2. A cell's stderr goes to the container runtime's log driver, where the fleet's collector drops complete non-JSON lines, so a sandbox whose whole job is decoding hostile bytes had one output channel that reached nobody.

Give each worker a pipe for fd 2, drain it non-blockingly inside the run loop, and attach the last 512 bytes to the `worker.killed` that reports its death and to the failure the caller receives. A worker that warns and then answers normally reports nothing: the field is here to make a death legible, not to ship a cell's stderr anywhere.

The worker's fd 2 stays non-blocking, set explicitly rather than left to `IO.pipe`'s own behaviour. A blocking fd 2 would make a warning written from inside libvips wait on the supervisor's scheduling, in a `write(2)` Ruby cannot interrupt, and that wait is nearest exactly when the host is under pressure. What it costs instead is a line when the pipe is already full. `docs/LOGS.md` states that, and what the field is and is not.

## What is deliberately not reported

A tool that dies while the worker survives — libgomp inside `magick` — produces no `worker.killed`, so its line is reported nowhere. That is a known cost of restricting the field to deaths, taken because a chatty library would otherwise put up to 512 bytes on every reap, and at the default `max_requests_per_worker: 1` that is every request. Revisit it when there is a clear need.

The capture is also loosely scoped and unauthenticated, which `docs/LOGS.md` states rather than papers over: it establishes neither who wrote the text nor which request it belongs to, because everything a worker spawned inherits fd 2 and a sibling worker can open `/proc/<pid>/fd/2` and write there. That is the caveat `hotcell.signal` and `hotcell.cause` already carry.

## Verified

Reproduced the incident in a container — `ruby:3.4-slim` plus `gcc libgomp1 libc6-dev`, a `#pragma omp parallel` program, `--pids-limit 32 -e OMP_NUM_THREADS=64 --user 10001:10001` — driven through a real cell in both shapes:

- an operation that `exec`s the program, so the worker's own address space dies: the caller gets `{"code":"killed","cause":"crashed","stderr":"\nlibgomp: Thread creation failed: Resource temporarily unavailable\n"}`, and the same text is on `worker.killed`.
- an operation that `system`s it, so a tool dies and the worker exits 0: the response is `ok` and no capture is reported anywhere, which is the cost named above.

Every test is negative-controlled — eight mutations, each turning the intended test red: no run-loop drain, an unsanitized field, head-keeping retention, `{ stderr: nil }` in place of `{}`, a blocking fd 2, an unbounded final drain, no per-dispatch clear, and a leaked pipe write end.

Two of those tests came out of an external review: a warning the worker survived must not be attached to a later request's death (needs `max_requests_per_worker: 2`, which the default never produces), and worker churn must leave no descriptors behind in the supervisor — dropping `stderr_writer.close` shows 15 descriptors where 11 belong. The same review caught `docs/LOGS.md` claiming an absent `worker.crashed` line *means* Ruby never raised; `Log#emit` drops lines when its sink is full, so it now says "consistent with".

One limit worth stating: the run-loop drain is only load-bearing above the pipe's capacity. Removed, the single-line tests still pass off the reap's final drain, and the flood test is what fails — the worker wedges. That test is what covers the branch.

