### PR TITLE
Stage an input's fd_path on darwin, where /dev/fd is a dup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ gem but are what an operator runs against their own image.
 
 ## next / unreleased
 
+### HotCell::Core
+
+#### Fixed
+
+* `Input#fd_path` stages its input on darwin, where `open("/dev/fd/N")` is a `dup` of fd N and shares its
+  offset rather than reopening the file at zero. A tool that opens the path more than once — libvips does,
+  once per candidate loader, to sniff a format — walked that offset forward, so a file whose loader is late
+  in the priority order came back `unreadable` with no error recorded. This only ever affected an
+  uncontainerized cell on macOS, which is the supported development path; Linux reopens and is unchanged.
+  The cost on darwin is a copy and the `RLIMIT_FSIZE` ceiling that bounds one.
+
 
 ## v0.3.0 / 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ gem but are what an operator runs against their own image.
   operation's `file_size` is refused there as a permanent `fsize` verdict rather than read in place. A
   refusal for a file too large to copy, in place of a wrong answer for an ordinary one.
 
+* `Input#path` copies from byte zero rather than from wherever the caller left the descriptor, and no
+  longer moves it. The descriptor arrives over `SCM_RIGHTS` and carries the caller's own file offset, so an
+  application that handed over an IO it had already read from was staged a copy with its prefix missing,
+  where `/dev/fd/N` reads the file whole.
+
 
 ## v0.3.0 / 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ gem but are what an operator runs against their own image.
   once per candidate loader, to sniff a format — walked that offset forward, so a file whose loader is late
   in the priority order came back `unreadable` with no error recorded. This only ever affected an
   uncontainerized cell on macOS, which is the supported development path; Linux reopens and is unchanged.
-  The cost on darwin is a copy and the `RLIMIT_FSIZE` ceiling that bounds one.
+  The cost on darwin is a copy and the `RLIMIT_FSIZE` ceiling that bounds one: an input larger than the
+  operation's `file_size` is refused there as a permanent `fsize` verdict rather than read in place. A
+  refusal for a file too large to copy, in place of a wrong answer for an ordinary one.
 
 
 ## v0.3.0 / 2026-09-01

--- a/README.md
+++ b/README.md
@@ -182,8 +182,10 @@ sequenceDiagram
 4. The worker narrows to the operation's limits, clamped to the cell's, before reading any untrusted byte,
    and re-runs `before_worker_boot` when the operation differs from the last one it served.
 5. `perform` runs on a fresh operation instance. An `Input` copies itself onto the slot's scratch the first
-   time the operation asks for its `path`; an operation that reads the descriptor directly never pays for
-   the copy. Outputs are posted back through their descriptors and flushed before success is reported.
+   time the operation asks for its `path`, and on darwin also for its `fd_path`, where `/dev/fd/N` is a dup
+   of the descriptor rather than a reopen of the file; an operation that reads the descriptor directly never
+   pays for the copy. Outputs are posted back through their descriptors and flushed before success is
+   reported.
 6. One JSON line answers: `ok` with the result and the timing, or a failure with its code.
 7. The supervisor enforces the deadline from outside, because a thread inside a C extension cannot be
    interrupted from within. A worker past its deadline is killed as a process group, and the supervisor --
@@ -468,9 +470,11 @@ class TransformImageOperation < HotCell::Operation
     source, = inputs
     destination, = outputs
 
-    # fd_path reads the caller's file in place, with no copy onto scratch, so an input of any size
-    # costs nothing against file_size. Reach for source.path only when a tool needs a distinct on-disk
-    # copy; that stages the bytes, and the kernel charges the write.
+    # fd_path reads the caller's file in place on Linux, with no copy onto scratch, so an input of any
+    # size costs nothing against file_size. On darwin it stages, because /dev/fd/N is a dup there rather
+    # than a reopen, so an input larger than file_size is refused as `fsize` on a development mac and
+    # analyzed in production. Reach for source.path only when a tool needs a distinct on-disk copy; that
+    # stages the bytes on both, and the kernel charges the write.
     MyImageProcessor.source(source.fd_path)
                     .apply(format:, operations)
                     .write_to(destination.fd_path)

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/previewers/video/ffmpeg.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/previewers/video/ffmpeg.rb
@@ -48,7 +48,8 @@ module ActiveStorage
               # past it as the fixed flags around them change.
               #
               # Both descriptors go to ffmpeg: it reads /dev/fd for the source and writes /dev/fd for the frame,
-              # so neither the input nor the output touches scratch. Writing the descriptor directly leaves
+              # so neither the input nor the output touches scratch on Linux. On darwin the source is staged
+              # first, so a video larger than this operation's file_size is refused there rather than previewed. Writing the descriptor directly leaves
               # partial bytes in the caller's file on a mid-write failure where a staged output would have left
               # it empty — harmless here, because run! turns a non-zero exit into a refusal and the previewer
               # discards its output on any failure, but it is a real property of the direct write.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -287,7 +287,9 @@ The cgroup limit is what bounds real memory across the cell.
 
 **An input is charged only when an operation asks for its path.** A descriptor that an operation reads in
 place costs no tmpfs and no `file_size`, so a multi-gigabyte upload can be analyzed under a small
-`file_size`. An operation that needs a filename copies the input onto scratch first, and the kernel
+`file_size`. On darwin `/dev/fd/N` does not reopen and every input named by `fd_path` is staged, so a
+development mac charges its inputs too and refuses one larger than `file_size` as `fsize`. Production is
+Linux and charges neither. An operation that needs a filename copies the input onto scratch first, and the kernel
 charges that copy exactly as it charges an output. Size `file_size` from the largest thing your operations
 write, and count a staged input as one of them.
 
@@ -446,9 +448,10 @@ servers:
 The sockets are `0660` and owned by the cell's user and group, so without the group your application
 cannot connect to a cell at all.
 
-And an operation that hands a tool a filename does not copy the input. It re-opens the descriptor as
-`/dev/fd/N`. That is a fresh open, and the kernel rechecks it against the **cell's** user rather than the
-caller's. The two sides do not share a uid, so a mode `0600` file the application owns gives `EACCES`. An
+And an operation that hands a tool a filename does not copy the input, on Linux. It re-opens the descriptor
+as `/dev/fd/N`. That is a fresh open, and the kernel rechecks it against the **cell's** user rather than the
+caller's. (On darwin that open is a dup rather than a reopen, so the input is staged and no recheck happens
+at all — the group is not what makes an uncontainerized macOS cell work.) The two sides do not share a uid, so a mode `0600` file the application owns gives `EACCES`. An
 Active Storage tempfile is exactly that.
 
 Six of the eight shipped Active Storage operations hand a tool a filename. The two `magick` ones do not,

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -291,6 +291,18 @@ implementation.
     not own the file. Changing a mode needs ownership, and `cap-drop ALL` leaves no capability that
     overrides it — so a shared group enforces the invariant and a shared uid cannot.
 
+19. **On darwin, `open("/dev/fd/N")` is a `dup` of fd N rather than a reopen of the file behind it.**
+    Linux's `/dev/fd` is `/proc/self/fd`, where the open is real and starts at offset zero; darwin's is
+    the `fdesc` filesystem, and its open shares the caller's file offset. A tool is free to open the path
+    it is handed more than once — libvips sniffs a format by opening it once per candidate loader and
+    reading the first few bytes — and on a shared offset each of those reads starts where the last one
+    stopped. A HEIC file, whose loader is late in libvips' priority order, is never recognised and comes
+    back `unreadable` with no error anywhere. Reopening the caller's own file is not available as a
+    remedy: its path is the cold side's, and no path the cold side chose is ever visible to a tool. So
+    `Input#fd_path` stages on
+    darwin, and an uncontainerized macOS cell pays for a copy and the `RLIMIT_FSIZE` ceiling that bounds
+    it. Production is Linux and pays neither.
+
 ## Why descriptors rather than a shared volume
 
 The obvious alternative is a directory mounted into both containers: the app writes an input file and

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -301,7 +301,8 @@ implementation.
     remedy: its path is the cold side's, and no path the cold side chose is ever visible to a tool. So
     `Input#fd_path` stages on
     darwin, and an uncontainerized macOS cell pays for a copy and the `RLIMIT_FSIZE` ceiling that bounds
-    it. Production is Linux and pays neither.
+    it — an input larger than the operation's `file_size` is refused there as `fsize` rather than read in
+    place. Production is Linux and pays neither.
 
 ## Why descriptors rather than a shared volume
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -289,7 +289,9 @@ implementation.
     The mode is also what enforces invariant 4 once a tool holds a filename: at `0400` even the owner is
     refused `O_RDWR`, and at `0200` even the owner is refused a read. That holds only while the cell does
     not own the file. Changing a mode needs ownership, and `cap-drop ALL` leaves no capability that
-    overrides it — so a shared group enforces the invariant and a shared uid cannot.
+    overrides it — so a shared group enforces the invariant and a shared uid cannot. All of this is the
+    reopening platform's; on darwin there is no reopen to check and an input named by `fd_path` is a copy
+    the cell itself owns, so neither the `EACCES` nor the mode enforcement above applies there. See 19.
 
 19. **On darwin, `open("/dev/fd/N")` is a `dup` of fd N rather than a reopen of the file behind it.**
     Linux's `/dev/fd` is `/proc/self/fd`, where the open is real and starts at offset zero; darwin's is

--- a/examples/lib/battery.rb
+++ b/examples/lib/battery.rb
@@ -93,7 +93,8 @@ module Examples
           result = Reopen.perform_in_hotcell([ input ], [ output ])
 
           assert_equal MESSAGE, File.binread(output_path), "the message carried through both paths"
-          assert_equal false, result[:staged], "a descriptor was staged onto scratch rather than used in place"
+          assert_equal !result[:reopens], result[:staged],
+            "a descriptor was staged onto scratch rather than used in place"
         end
       end
 

--- a/examples/operations/reopen.rb
+++ b/examples/operations/reopen.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-# The same round trip as echo, through both paths instead of both descriptors. `/dev/fd/N` is a fresh
-# open, rechecked against the opening process's uid and the file's mode, so this succeeds only when the
-# cell can open the caller's own files by name. Echo consumes the descriptors directly and never
+# The same round trip as echo, through both paths instead of both descriptors. On Linux `/dev/fd/N` is a
+# fresh open, rechecked against the opening process's uid and the file's mode, so this succeeds only when
+# the cell can open the caller's own files by name. Echo consumes the descriptors directly and never
 # establishes that, which is why both exist.
+#
+# On darwin that open is a `dup` instead, so an input names a staged copy and this establishes nothing
+# about permissions there. `reopens` says which of the two the cell answered from, because a cell need not
+# run on the platform the battery does.
 #
 # Both directions, because they are different permissions and a tool may need either: an input is readable
 # by the group and an output is writable by it, and one of the shipped operations re-opens each. Reading
@@ -23,7 +27,8 @@ module Examples
         File.open(destination.fd_path, "wb") { |output| output.write(input.read) }
       end
 
-      { bytes: bytes, staged: source.staged? || destination.staged? }
+      { bytes: bytes, staged: source.staged? || destination.staged?,
+        reopens: HotCell::Descriptor.reopens_descriptors? }
     end
   end
 end

--- a/hotcell-core/lib/hot_cell/descriptors.rb
+++ b/hotcell-core/lib/hot_cell/descriptors.rb
@@ -36,11 +36,16 @@ module HotCell
     # sees it too when the worker hands the fd across the exec at the same number — see Operation#run_tool.
     #
     # This is what keeps a multi-gigabyte input off a small tmpfs: the descriptor is the caller's own file,
-    # readable at any size, where staging it would be a write and RLIMIT_FSIZE bounds writes. Reopening
-    # `/dev/fd/N` gives a fresh file description at offset zero, so a read here does not disturb the
-    # descriptor the supervisor still holds.
+    # readable at any size, where staging it would be a write and RLIMIT_FSIZE bounds writes. On Linux,
+    # reopening `/dev/fd/N` gives a fresh file description at offset zero, so a read here does not disturb
+    # the descriptor the supervisor still holds. Darwin's fdesc filesystem does not — see Input#fd_path.
     def fd_path
       "/dev/fd/#{io.fileno}"
+    end
+
+    # Whether this platform's `/dev/fd/N` is a reopen of the file behind fd N, or a dup of fd N itself.
+    def self.reopens_descriptors?
+      !RUBY_PLATFORM.include?("darwin")
     end
 
     def close
@@ -102,6 +107,20 @@ module HotCell
     # On call rather than up front, so an operation that never asks for a staged path never pays for the copy.
     def path
       @path ||= copied_to(scratch_path)
+    end
+
+    # Staged rather than named on darwin, where `open("/dev/fd/N")` is a dup of fd N and shares its offset
+    # rather than starting a fresh read at zero. A tool is free to open the path it is handed more than
+    # once — libvips sniffs an image's format by opening it once per candidate loader and reading the first
+    # few bytes — and on a shared offset each of those reads starts where the last one stopped. A loader
+    # late in the priority order then never sees the file's magic, and a readable file comes back
+    # unreadable. Reopening the caller's own file instead is not available here by design: its path is the
+    # cold side's and no tool is to see it.
+    #
+    # So darwin pays for a copy and for the RLIMIT_FSIZE ceiling that bounds it, which is the cost of an
+    # uncontainerized cell answering what the Linux one answers. Production is Linux and pays neither.
+    def fd_path
+      self.class.reopens_descriptors? ? super : path
     end
 
     private

--- a/hotcell-core/lib/hot_cell/descriptors.rb
+++ b/hotcell-core/lib/hot_cell/descriptors.rb
@@ -124,14 +124,24 @@ module HotCell
     end
 
     private
-      # From byte zero rather than from wherever the descriptor is sitting, and without moving it. The
+      # From byte zero rather than from wherever the descriptor is sitting, and left where it was found. The
       # descriptor arrives over SCM_RIGHTS, so it carries the caller's own file offset: an application that
       # handed over an IO it had already read from would otherwise be staged a copy with its prefix
       # missing, where `/dev/fd/N` on a reopening platform reads the file whole. What a tool is given must
       # not depend on which of the two routes it came by.
+      #
+      # Seek and restore rather than `IO.copy_stream`'s own `src_offset`, which darwin ignores: there it
+      # copies with `fcopyfile` and the offset argument does not reach it, so a positional copy silently
+      # became a copy from the caller's position — on the one platform that now stages for every operation.
+      # Nothing else reads this descriptor while the copy runs: the client is blocked on the response and
+      # the worker serves one request.
       def copied_to(path)
-        File.open(path, "wb") { |file| IO.copy_stream(io, file, nil, 0) }
+        position = io.pos
+        io.pos = 0
+        File.open(path, "wb") { |file| IO.copy_stream(io, file) }
         path
+      ensure
+        io.pos = position
       end
   end
 

--- a/hotcell-core/lib/hot_cell/descriptors.rb
+++ b/hotcell-core/lib/hot_cell/descriptors.rb
@@ -124,8 +124,13 @@ module HotCell
     end
 
     private
+      # From byte zero rather than from wherever the descriptor is sitting, and without moving it. The
+      # descriptor arrives over SCM_RIGHTS, so it carries the caller's own file offset: an application that
+      # handed over an IO it had already read from would otherwise be staged a copy with its prefix
+      # missing, where `/dev/fd/N` on a reopening platform reads the file whole. What a tool is given must
+      # not depend on which of the two routes it came by.
       def copied_to(path)
-        File.open(path, "wb") { |file| IO.copy_stream(io, file) }
+        File.open(path, "wb") { |file| IO.copy_stream(io, file, nil, 0) }
         path
       end
   end

--- a/hotcell-core/lib/hot_cell/descriptors.rb
+++ b/hotcell-core/lib/hot_cell/descriptors.rb
@@ -99,8 +99,9 @@ module HotCell
 
     # Copies the bytes onto the worker's own scratch on the first call and returns the filename. This is the
     # fallback, for an operation that genuinely needs a real file. Prefer `fd_path`, which reads the
-    # descriptor in place: staging is a write, so RLIMIT_FSIZE bounds it, and an input larger than the
-    # operation's file_size dies here as a permanent `fsize` verdict — a ceiling Rails does not have. The
+    # descriptor in place wherever `/dev/fd` reopens — Linux, and so production; see below for darwin, which
+    # stages and pays this same cost. Staging is a write, so RLIMIT_FSIZE bounds it, and an input larger than
+    # the operation's file_size dies here as a permanent `fsize` verdict — a ceiling Rails does not have. The
     # Active Storage operations all read `fd_path` for exactly that reason; nothing should reach for `path`
     # without a specific need for a distinct on-disk copy.
     #

--- a/hotcell-core/lib/hot_cell/descriptors.rb
+++ b/hotcell-core/lib/hot_cell/descriptors.rb
@@ -96,6 +96,7 @@ module HotCell
 
   class Input < Descriptor
     ACCESS_MODE = Fcntl::O_RDONLY
+    STAGE_CHUNK = 1024 * 1024
 
     # Copies the bytes onto the worker's own scratch on the first call and returns the filename. This is the
     # fallback, for an operation that genuinely needs a real file. Prefer `fd_path`, which reads the
@@ -125,24 +126,35 @@ module HotCell
     end
 
     private
-      # From byte zero rather than from wherever the descriptor is sitting, and left where it was found. The
-      # descriptor arrives over SCM_RIGHTS, so it carries the caller's own file offset: an application that
-      # handed over an IO it had already read from would otherwise be staged a copy with its prefix
-      # missing, where `/dev/fd/N` on a reopening platform reads the file whole. What a tool is given must
-      # not depend on which of the two routes it came by.
+      # From byte zero rather than from wherever the descriptor is sitting. The descriptor arrives over
+      # SCM_RIGHTS, so it carries the caller's own file offset: an application that handed over an IO it
+      # had already read from would otherwise be staged a copy with its prefix missing, where `/dev/fd/N`
+      # on a reopening platform reads the file whole. What a tool is given must not depend on which of the
+      # two routes it came by.
       #
-      # Seek and restore rather than `IO.copy_stream`'s own `src_offset`, which darwin ignores: there it
-      # copies with `fcopyfile` and the offset argument does not reach it, so a positional copy silently
-      # became a copy from the caller's position — on the one platform that now stages for every operation.
-      # Nothing else reads this descriptor while the copy runs: the client is blocked on the response and
-      # the worker serves one request.
+      # `pread` rather than a seek, because the offset is not this side's to move. SCM_RIGHTS shares the
+      # open file description, so `io.pos = 0` here is a write to the application's own IO — and only the
+      # thread that called is blocked on the response, so another of its threads reading that IO would read
+      # from a position this worker set. Reading positionally leaves nothing to restore and no window in
+      # which the caller can observe an offset it did not choose. `IO.copy_stream`'s own `src_offset` is
+      # not that: darwin copies with `fcopyfile`, where the argument never arrives and the copy silently
+      # starts at the caller's position instead.
       def copied_to(path)
-        position = io.pos
-        io.pos = 0
-        File.open(path, "wb") { |file| IO.copy_stream(io, file) }
+        File.open(path, "wb") do |file|
+          offset = 0
+          while (chunk = read_at(offset))
+            file.write chunk
+            offset += chunk.bytesize
+          end
+        end
+
         path
-      ensure
-        io.pos = position
+      end
+
+      def read_at(offset)
+        io.pread(STAGE_CHUNK, offset)
+      rescue EOFError
+        nil
       end
   end
 

--- a/hotcell-core/test/descriptors_test.rb
+++ b/hotcell-core/test/descriptors_test.rb
@@ -60,6 +60,55 @@ class DescriptorsTest < HotCellTest
     end
   end
 
+  # Every operation that hands a tool a filename hands it this one, and a tool is free to open it more
+  # than once: libvips sniffs an image's format by opening the path once per candidate loader and reading
+  # the first few bytes. Each of those opens has to start at the beginning, whatever the platform makes of
+  # /dev/fd — on darwin the open is a dup and the reads would otherwise walk a shared offset forward,
+  # leaving a file whose loader is late in the priority order unrecognised.
+  def test_reading_an_inputs_fd_path_twice_reads_the_same_bytes
+    with_file("0123456789abcdef") do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "input") })
+
+          assert_equal "0123", File.open(input.fd_path, "rb") { |file| file.read(4) }
+          assert_equal "0123", File.open(input.fd_path, "rb") { |file| file.read(4) }
+        end
+      end
+    end
+  end
+
+  # The bytes a tool reads through the path are the caller's, whichever route the platform takes to them.
+  def test_an_inputs_fd_path_reads_the_callers_bytes
+    with_file("source bytes") do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "input") })
+
+          assert_equal "source bytes", File.binread(input.fd_path)
+        end
+      end
+    end
+  end
+
+  # The darwin branch, run everywhere: the two tests above pass on Linux without the branch existing at
+  # all, and the platform that needs it is not in the gating CI lane for this suite.
+  def test_an_input_stages_where_the_platform_does_not_reopen_descriptors
+    with_file("0123456789abcdef") do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "input") })
+
+          without_reopened_descriptors do
+            assert_equal "0123", File.open(input.fd_path, "rb") { |file| file.read(4) }
+            assert_equal "0123", File.open(input.fd_path, "rb") { |file| file.read(4) }
+            assert_equal input.path, input.fd_path
+          end
+        end
+      end
+    end
+  end
+
   def test_asking_an_input_for_its_path_copies_its_bytes_to_a_filename_the_cold_side_never_named
     with_file("source bytes") do |source|
       Dir.mktmpdir do |scratch|
@@ -221,4 +270,15 @@ class DescriptorsTest < HotCellTest
       writing(path) { |io| assert HotCell::Output.new(io) }
     end
   end
+
+  private
+    # What this answers is a property of the platform, so the branch the machine is not on is only
+    # reachable by saying so. Defined on the subclass rather than on Descriptor, whose own singleton
+    # carries the real one.
+    def without_reopened_descriptors
+      HotCell::Input.define_singleton_method(:reopens_descriptors?) { false }
+      yield
+    ensure
+      HotCell::Input.singleton_class.remove_method :reopens_descriptors?
+    end
 end

--- a/hotcell-core/test/descriptors_test.rb
+++ b/hotcell-core/test/descriptors_test.rb
@@ -123,6 +123,39 @@ class DescriptorsTest < HotCellTest
     end
   end
 
+  # The descriptor carries the caller's own offset across SCM_RIGHTS, and neither route to the bytes may
+  # depend on it: `/dev/fd/N` on a reopening platform reads the file whole, so staging has to as well.
+  def test_staging_an_input_the_caller_had_already_read_from_copies_the_whole_file
+    with_file("0123456789abcdef") do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          io.read(4)
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "input") })
+
+          assert_equal "0123456789abcdef", File.binread(input.path)
+          assert_equal 4, io.pos
+        end
+      end
+    end
+  end
+
+  def test_an_inputs_fd_path_ignores_the_offset_the_caller_left_behind
+    with_file("0123456789abcdef") do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          io.read(4)
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "input") })
+
+          assert_equal "0123", File.open(input.fd_path, "rb") { |file| file.read(4) }
+
+          without_reopened_descriptors do
+            assert_equal "0123", File.open(input.fd_path, "rb") { |file| file.read(4) }
+          end
+        end
+      end
+    end
+  end
+
   def test_an_input_copies_once_and_answers_the_same_path_after_that
     with_file("source bytes") do |source|
       Dir.mktmpdir do |scratch|

--- a/hotcell-core/test/descriptors_test.rb
+++ b/hotcell-core/test/descriptors_test.rb
@@ -139,6 +139,62 @@ class DescriptorsTest < HotCellTest
     end
   end
 
+  # The descriptor shares its open file description, and so its offset, with the application's own IO: only
+  # the thread that called is blocked on the response, so a seek here is a write to something another of
+  # the caller's threads may be reading. Staging must therefore not seek at all, which is a stronger claim
+  # than leaving the offset where it was found — seek-and-restore also does that, everywhere except the
+  # window in between, and that window is not observable from a test without racing it.
+  def test_staging_an_input_never_seeks_the_descriptor_the_caller_shares
+    with_file("0123456789abcdef") do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          io.read(4)
+          seeks = watch_seeks(io)
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "input") })
+          staged = input.path
+
+          assert_empty seeks, "staging seeked a descriptor it shares with the caller"
+          assert_equal "0123456789abcdef", File.binread(staged)
+          assert_equal 4, io.pos
+          assert_equal "456789abcdef", io.read
+        end
+      end
+    end
+  end
+
+  # And nothing writes the offset on the way out either, so a copy that cannot be made leaves it alone.
+  def test_a_staging_copy_that_fails_leaves_the_descriptors_offset_alone
+    with_file("0123456789abcdef") do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          io.read(4)
+          seeks = watch_seeks(io)
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "absent", "input") })
+
+          assert_raises(SystemCallError) { input.path }
+          assert_empty seeks, "staging seeked a descriptor it shares with the caller"
+          assert_equal 4, io.pos
+        end
+      end
+    end
+  end
+
+  # More bytes than one positional read returns, so the loop that assembles them is covered rather than
+  # skipped by every fixture being smaller than a single chunk.
+  def test_staging_an_input_larger_than_one_read_copies_every_byte
+    bytes = "0123456789abcdef" * (HotCell::Input::STAGE_CHUNK / 8)
+
+    with_file(bytes) do |source|
+      Dir.mktmpdir do |scratch|
+        reading(source) do |io|
+          input = HotCell::Input.new(io, scratch: -> { File.join(scratch, "input") })
+
+          assert_equal bytes, File.binread(input.path)
+        end
+      end
+    end
+  end
+
   def test_an_inputs_fd_path_ignores_the_offset_the_caller_left_behind
     with_file("0123456789abcdef") do |source|
       Dir.mktmpdir do |scratch|
@@ -308,6 +364,13 @@ class DescriptorsTest < HotCellTest
     # What this answers is a property of the platform, so the branch the machine is not on is only
     # reachable by saying so. Defined on the subclass rather than on Descriptor, whose own singleton
     # carries the real one.
+    # Records rather than refuses, so the assertion that reports the seek is the one that names it.
+    def watch_seeks(io)
+      [].tap do |seeks|
+        io.define_singleton_method(:pos=) { |offset| seeks << offset }
+      end
+    end
+
     def without_reopened_descriptors
       HotCell::Input.define_singleton_method(:reopens_descriptors?) { false }
       yield

--- a/hotcell-server/lib/hot_cell/configuration.rb
+++ b/hotcell-server/lib/hot_cell/configuration.rb
@@ -13,6 +13,10 @@ module HotCell
   # operation that consumes the descriptor never pays for its input, which is what lets a small file_size
   # accept a large upload — but the kernel does not distinguish the two writes, so one number covers both.
   #
+  # That holds where `/dev/fd/N` reopens the file behind it, which is Linux and so production. On darwin it
+  # is a dup and every input named by `fd_path` is staged (Input#fd_path), so a development mac pays
+  # file_size for its inputs as well and needs headroom for the largest one it will be handed.
+  #
   # memory does not multiply by concurrency, and that is the easiest mistake to make here. It is an
   # address-space charge on one worker. The cgroup limit is what bounds real memory across the cell, and
   # it counts the tmpfs too, so size the two separately.

--- a/hotcell-server/lib/hot_cell/operation.rb
+++ b/hotcell-server/lib/hot_cell/operation.rb
@@ -150,7 +150,8 @@ module HotCell
     # verdict, which is permanent, for a document whose only crime was being noisy.
     # `pass` hands the tool a set of the worker's own descriptors — an input to read, an output to write —
     # at their existing fd numbers, so the tool reaches them as `/dev/fd/N` (Descriptor#fd_path) and no
-    # byte is copied onto scratch to give it a filename. A fd handed to a child this way loses its
+    # byte is copied onto scratch to give it a filename — on Linux, where that path reopens the file. On
+    # darwin `Input#fd_path` stages instead and the copy is charged, which `pass:` does not change. A fd handed to a child this way loses its
     # close-on-exec, which is exactly the inheritance wanted, and only for these; the worker's other
     # descriptors are untouched. Passing an fd at its own number cannot collide with the stdio pipes popen3
     # installs on 0, 1 and 2, because a received descriptor is never one of those.

--- a/hotcell-server/lib/hot_cell/test_operations.rb
+++ b/hotcell-server/lib/hot_cell/test_operations.rb
@@ -325,7 +325,8 @@ module HotCell
 
     # Hands an exec'd tool the input descriptor and has it read the bytes back through /dev/fd, so a test
     # can prove run_tool's `pass:` exposes a descriptor to a tool without staging it. Reports whether the
-    # input was copied onto scratch, which must be false.
+    # input was copied onto scratch, which must be false where `/dev/fd/N` reopens and true on darwin,
+    # where it does not — the test asserts against the platform rather than against false.
     class ReadThroughFd < HotCell::Operation
       operation "test.read_through_fd"
 

--- a/hotcell-server/test/run_tool_test.rb
+++ b/hotcell-server/test/run_tool_test.rb
@@ -5,6 +5,10 @@ require "test_helper"
 # run_tool's `pass:` hands a spawned tool one of the worker's own descriptors, so the tool reads it as
 # /dev/fd/N without a byte being copied onto scratch. This is what lets an operation feed an input of any
 # size to a tool under a file_size that bounds only what the worker writes.
+#
+# Both of those hold only where `/dev/fd/N` reopens the file behind fd N. Where it is a dup of fd N
+# instead an input is staged, and both tests state the other side rather than skipping it, because that
+# platform is what Input#fd_path's branch is for.
 class RunToolTest < HotCellServerTest
   def test_a_passed_descriptor_reaches_the_tool_through_dev_fd
     with_file("bytes the tool reads back through its own fd") do |source|
@@ -12,7 +16,8 @@ class RunToolTest < HotCellServerTest
         result = assert_ok(cell.call("test.read_through_fd", inputs: [ source ])).result
 
         assert_equal "bytes the tool reads back through its own fd", result[:content]
-        refute result[:staged], "the input was copied onto scratch instead of read in place"
+        assert_equal !HotCell::Descriptor.reopens_descriptors?, result[:staged],
+          "the input was copied onto scratch instead of read in place"
       end
     end
   end
@@ -20,13 +25,23 @@ class RunToolTest < HotCellServerTest
   # The point of reading in place: file_size bounds writes, and a passed descriptor is a read. An input
   # larger than the limit reaches the tool, where staging it would have died with SIGXFSZ. Kept under the
   # response limit so the whole input can ride back for the length check.
+  #
+  # A staging platform gets that ceiling back, which is the one thing this fix costs: an input larger than
+  # the operation's file_size is refused there rather than analyzed. It is a permanent `fsize` verdict, not
+  # a wrong answer.
   def test_an_input_larger_than_the_write_limit_reaches_the_tool
     with_file("x" * (40 * 1024)) do |source|
       TestCell.boot(file_size: 16 * 1024) do |cell|
-        result = assert_ok(cell.call("test.read_through_fd", inputs: [ source ])).result
+        response = cell.call("test.read_through_fd", inputs: [ source ])
 
-        assert_equal 40 * 1024, result[:content].bytesize
-        refute result[:staged], "a large input was staged instead of read in place"
+        if HotCell::Descriptor.reopens_descriptors?
+          result = assert_ok(response).result
+
+          assert_equal 40 * 1024, result[:content].bytesize
+          refute result[:staged], "a large input was staged instead of read in place"
+        else
+          assert_failed "killed", response, cause: "fsize"
+        end
       end
     end
   end


### PR DESCRIPTION
A Basecamp developer's `ActiveStorage::Analyzer::CellVipsAnalyzerTest` failed on `monochrom.heic` on macOS, and only there:

```
--- expected
+++ actual
-{pages: 1, loader: :heif, format: :heic, mime_type: "image/heic", ...}
+{}
```

`Descriptor#fd_path` hands every tool `/dev/fd/N`, and its comment states the assumption the whole mechanism rests on: reopening that path gives a fresh file description at offset zero. On Linux `/dev/fd` is `/proc/self/fd` and that is true. On darwin it is the `fdesc` filesystem, where the open is a `dup` of fd N and shares the caller's file offset.

libvips finds a loader by trying each candidate in priority order, and every `is_a` check opens the path and reads the first few bytes. On darwin those reads walk one shared offset forward, so `jpegload` — which runs first — leaves `heifload` reading bytes 12–23, where there is no `ftyp`. libvips answers that it does not know the format, the operation answers `unreadable`, and the application stores `{}` with no error recorded anywhere.

This is not one test, and it is not only libvips. I counted opens of the input path per invocation, two ways — an `LD_PRELOAD` shim over `open`/`openat`/`fopen`, and `inotifywait -e open` — with the flags the shipped operations actually pass:

| tool | opens of the input path |
|---|---|
| `vips` | 7–9 |
| `mutool draw` | 2 |
| `pdftoppm` | 1 |
| `ffprobe` | 1 |
| `ffmpeg` | 1 |

So both vips operations and the `mutool` PDF previewer reopen and are broken by this; `ffprobe`, `ffmpeg` and `pdftoppm` open once and this mechanism never reached them. `monochrom.heic` is simply the fixture whose loader is late enough to lose. Production is Linux and is unaffected.

Those three are still exposed to the other half of the dup, which no count can rule out: `open("/dev/fd/N")` starts at whatever offset the descriptor arrived carrying, so a caller that had already read from the IO hands them a file beginning in the middle. Active Storage opens a fresh tempfile, so that is latent rather than firing.

## The fix

`Input#fd_path` stages on darwin and names the descriptor everywhere else.

Reopening the caller's own file is the remedy that would cost nothing, and it is not available here: that path is the cold side's, and no path the cold side chose is ever visible to a tool. So darwin pays for a copy and for the `RLIMIT_FSIZE` ceiling that bounds one, which is what an uncontainerized cell costs to make it answer what the Linux one answers. Linux pays neither.

### Why not rewind the descriptor

Because the bug is not that the read starts in the wrong place. It is that there is more than one read.

Every open of `/dev/fd/N` on darwin shares one file offset, with fd N and with each other. Rewinding before the handoff makes `jpegload`'s probe correct and leaves the shared offset at 12 for the next one, so `heifload` still never sees `ftyp`. The reported failure is already that state — the analyzer hands over a freshly opened file sitting at zero — so a rewind at handoff is a no-op on the case that started this. There is no seam to rewind between the probes either: they are inside libvips within one call, and under `run_tool` in another process after the exec. Anything rewinding alongside the tool would race the tool's own reads and would be moving an offset that belongs to the caller.

The rewind is in the fix regardless, for the other bug it does answer — see "The staged copy started in the wrong place" below.

Fixing this in the vips operations instead — `Vips::Source.new_from_descriptor`, which does work — was rejected, and the counts above are why. It leaves the `mutool` previewer broken on the same platform for the same reason, and `mutool` is a spawned binary handed a filename: there is no descriptor API to swap in for it, so staging is the only remedy it has. A vips-only fix would therefore have to be joined by staging anyway, for a second tool, while `fd_path` kept a contract that differed by platform. It also changes the `vips-loader` string an operation reports from `heifload` to `heifload_source`, which is a value clients map.

Staging only for the tools that reopen was considered and rejected too: `Input` cannot know which tool the operation will hand the path to, so this would need a per-operation declaration, and an operation that declared wrong would fail exactly the way this PR is fixing — silently, on one platform.

## The reopen probe

`example.reopen` exists to establish that the cell can open the caller's files by name, which is a permission question and a Linux one. On darwin an input now names a staged copy, so the probe establishes nothing there and `staged` is true. It reports `reopens` alongside, and the battery asserts against that rather than against `false`, because a cell need not run on the platform the battery does. Without this the battery goes red on macOS, where CI runs it.

## What it costs, which the macOS lane measured

`run_tool` makes two promises that hold only where `/dev/fd/N` reopens: an input is read in place, and an input larger than the operation's `file_size` still reaches the tool, because that limit bounds writes. Staging gives up both on darwin, and `run_tool_test.rb` failed on exactly those two assertions in the macOS lane on the first push:

```
1) RunToolTest#test_a_passed_descriptor_reaches_the_tool_through_dev_fd
   the input was copied onto scratch instead of read in place
2) RunToolTest#test_an_input_larger_than_the_write_limit_reaches_the_tool
   expected ok and got "killed: fsize: Errno::EFBIG: File too large - fcopyfile"
```

The second is the real cost and it is worth naming plainly: on macOS an input larger than the operation's `file_size` is now refused rather than analyzed. That is a permanent `fsize` verdict for a file too large to copy, in place of a silently wrong answer for an ordinary one, on the development platform only. Both tests now state the other side rather than skipping it.

**What a developer on macOS will see.** Yes — the blob ends up marked analyzed with empty metadata, and is never retried. `fsize` is permanent, and `Analyzing#metadata` rescues a permanent failure, logs `hotcell: <filename> could not be analyzed and will not be retried`, and returns `{}` — so Rails marks the blob analyzed with empty metadata. On macOS after this, a video over 128MB (`ffmpeg`), or a video or image over 48MB (`ffprobe`, the vips analyzer), gets empty metadata and one warning line in the development log. The mechanism is not new — any input staged through `path` over `file_size` has always done this, which is how the two `magick` operations already behave — but this change puts every darwin input on that path.

I am accepting that rather than fixing it here. It is the development platform, it is loud in the log rather than silent, and production is Linux and unaffected. The fix that would be honest is a distinct non-permanent verdict meaning "this cell could not stage an input this large," which is neither `fsize` nor a retry that can never succeed — a new code on a wire protocol Linux shares, which is a larger change than a darwin bug deserves and should be argued on its own. Named here as follow-up rather than folded in; it has no issue yet and should get one if this merges.

## The staged copy started in the wrong place

Caught in review, and worth calling out because the first attempt at it was wrong on the platform it was for. `Input#path` copied with `IO.copy_stream` from wherever the descriptor was sitting, and it arrives over `SCM_RIGHTS` carrying the caller's own file offset — so an application that handed over an IO it had already read from was staged a copy with its prefix missing, where `/dev/fd/N` reads the file whole. Pre-existing, but routing darwin through `path` is what made it reachable for every operation on a whole platform.

`IO.copy_stream(io, file, nil, 0)` fixes that on Linux and not on darwin, where the copy goes through `fcopyfile` and the offset argument never reaches it. The macOS lane caught that on both of the tests the fix added. It now seeks to zero, copies, and restores the position in an `ensure`, which no platform can reinterpret.

## Verified, and the bound on it

`rake test:hotcell` and `rake test:activestorage` are green on Linux — 109, 84, 220, 82 and 53 runs — along with the conformance gate, the battery and rubocop.

`hotcell-core/test/descriptors_test.rb` gets three tests: two for the invariant a tool depends on, and one that forces the darwin branch on so the branch is covered on Linux too. That third one is the negative control — with the `Input#fd_path` override removed it fails, where the first two pass on Linux either way.

**I have no Mac**, so the failure above is a report rather than something I reproduced. The macOS CI lane is what stands in for one: all three new tests ran and passed there, including the one that reads an input's `fd_path` twice and requires both reads to start at byte zero. That is the invariant this fixes, checked on darwin.

## Downstream

An application that treats a staged input as a failed check will see that check fail on macOS after this. Basecamp's `BC3::Saas::Cell#verified` is one, and needs a matching change when it takes the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





