### PR TITLE
Answer `fd_path` with a real filename on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ gem but are what an operator runs against their own image.
 
 ## next / unreleased
 
+### HotCell::Core
+
+#### Fixed
+
+* `Descriptor#fd_path` answers with the filename behind the descriptor on macOS rather than `/dev/fd/N`. Opening `/dev/fd/N` is a real open on Linux and a `dup(2)` on macOS, where `/dev/fd` has no procfs behind it, so every opener shared one offset: libvips, which opens the path once per candidate loader while it sniffs a format, read past a HEIC file's magic bytes and reported a readable file as `unreadable`. macOS is a development platform for a cell and nothing else — uncontainerized, running as the caller — so this trades away the property that no path the cold side chose is visible to a tool, on the one platform where that path was already within reach. Linux is untouched.
+
 
 ## v0.3.0 / 2026-09-01
 

--- a/examples/operations/reopen.rb
+++ b/examples/operations/reopen.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# The same round trip as echo, through both paths instead of both descriptors. `/dev/fd/N` is a fresh
-# open, rechecked against the opening process's uid and the file's mode, so this succeeds only when the
-# cell can open the caller's own files by name. Echo consumes the descriptors directly and never
+# The same round trip as echo, through both paths instead of both descriptors. `fd_path` is a fresh open by
+# name — `/dev/fd/N` on Linux, the file's own path on macOS — rechecked against the opening process's uid
+# and the file's mode, so this succeeds only when the cell can open the caller's own files by name. Echo consumes the descriptors directly and never
 # establishes that, which is why both exist.
 #
 # Both directions, because they are different permissions and a tool may need either: an input is readable

--- a/hotcell-core/lib/hot_cell/descriptors.rb
+++ b/hotcell-core/lib/hot_cell/descriptors.rb
@@ -40,23 +40,22 @@ module HotCell
     # `/dev/fd/N` gives a fresh file description at offset zero, so a read here does not disturb the
     # descriptor the supervisor still holds.
     #
-    # Darwin gets a different implementation of that promise, because it cannot keep it this way. There is
-    # no procfs behind `/dev/fd`, so opening the path is dup(2): one shared offset, and a reader that has
-    # read leaves the next open mid-file. libvips sniffs a format by opening the path once per candidate
-    # loader, so the second loader reads past the magic bytes and a readable file is called unreadable.
+    # Darwin cannot keep that promise, so it keeps the behavior instead. `/dev/fd` has no procfs behind it
+    # there, and opening the path is dup(2): one shared offset, so what one reader consumes the next open
+    # skips. libvips sniffs a format by opening the path once per candidate loader, so the second loader
+    # reads past the magic bytes and a readable file is called unreadable.
     #
-    # Darwin answers with the filename behind the descriptor instead, which a by-name open does start at
-    # zero. That is a corner cut on purpose: it hands a tool a path the cold side chose, which the rest of
-    # this class exists to prevent. Darwin is a development platform and nothing else — no container, no
-    # isolation, the cell running as the caller on the caller's own filesystem, where that path was already
-    # within reach and hiding it protected nothing. What has to match on the two platforms is the behavior
-    # an operation sees: a path that reads the input from its first byte, however many times it is opened.
-    # How that is arrived at does not have to match, and here it does not.
+    # Darwin answers with the filename behind the descriptor, which a by-name open does start at zero. That
+    # hands a tool a path the cold side chose, which the rest of this class exists to prevent — a corner cut
+    # on purpose. Darwin is a development platform and nothing else: no container, no isolation, the cell
+    # running as the caller on the caller's own filesystem, where hiding a path it could already reach
+    # protected nothing. What has to match across platforms is what an operation sees — a path that reads
+    # from the first byte however many times it is opened — not how that is arrived at.
     if RUBY_PLATFORM.include?("darwin")
       F_GETPATH = 50 # sys/fcntl.h; Ruby's Fcntl module does not carry it
 
       def fd_path
-        buffer = "\0" * 1024 # MAXPATHLEN, which the kernel fills in place
+        buffer = "\0" * 1024 # F_GETPATH writes the path into a buffer the caller supplies, MAXPATHLEN wide
         io.fcntl F_GETPATH, buffer
         buffer[/\A[^\0]+/]
       end

--- a/hotcell-core/lib/hot_cell/descriptors.rb
+++ b/hotcell-core/lib/hot_cell/descriptors.rb
@@ -39,8 +39,31 @@ module HotCell
     # readable at any size, where staging it would be a write and RLIMIT_FSIZE bounds writes. Reopening
     # `/dev/fd/N` gives a fresh file description at offset zero, so a read here does not disturb the
     # descriptor the supervisor still holds.
-    def fd_path
-      "/dev/fd/#{io.fileno}"
+    #
+    # Darwin gets a different implementation of that promise, because it cannot keep it this way. There is
+    # no procfs behind `/dev/fd`, so opening the path is dup(2): one shared offset, and a reader that has
+    # read leaves the next open mid-file. libvips sniffs a format by opening the path once per candidate
+    # loader, so the second loader reads past the magic bytes and a readable file is called unreadable.
+    #
+    # Darwin answers with the filename behind the descriptor instead, which a by-name open does start at
+    # zero. That is a corner cut on purpose: it hands a tool a path the cold side chose, which the rest of
+    # this class exists to prevent. Darwin is a development platform and nothing else — no container, no
+    # isolation, the cell running as the caller on the caller's own filesystem, where that path was already
+    # within reach and hiding it protected nothing. What has to match on the two platforms is the behavior
+    # an operation sees: a path that reads the input from its first byte, however many times it is opened.
+    # How that is arrived at does not have to match, and here it does not.
+    if RUBY_PLATFORM.include?("darwin")
+      F_GETPATH = 50 # sys/fcntl.h; Ruby's Fcntl module does not carry it
+
+      def fd_path
+        buffer = "\0" * 1024 # MAXPATHLEN, which the kernel fills in place
+        io.fcntl F_GETPATH, buffer
+        buffer[/\A[^\0]+/]
+      end
+    else
+      def fd_path
+        "/dev/fd/#{io.fileno}"
+      end
     end
 
     def close

--- a/hotcell-core/test/descriptors_test.rb
+++ b/hotcell-core/test/descriptors_test.rb
@@ -192,6 +192,22 @@ class DescriptorsTest < HotCellTest
     end
   end
 
+  # fd_path claims a reopen is a fresh file description at offset zero, so a tool may read the input and
+  # the supervisor's own descriptor is left where it was. On macOS opening /dev/fd/N dups the descriptor
+  # instead, so the offset is shared: the second reader resumes where the first stopped. libvips opens the
+  # path once per loader while it sniffs, which is how a HEIC file becomes unreadable there.
+  def test_reopening_fd_path_reads_from_zero_and_leaves_the_descriptor_alone
+    with_file("source bytes") do |path|
+      reading(path) do |io|
+        input = HotCell::Input.new(io)
+
+        assert_equal "source", File.open(input.fd_path, "rb") { |reopened| reopened.read(6) }
+        assert_equal "source", File.open(input.fd_path, "rb") { |reopened| reopened.read(6) }
+        assert_equal 0, io.pos
+      end
+    end
+  end
+
   def test_closing_twice_is_harmless
     with_file do |path|
       reading(path) do |io|

--- a/hotcell-core/test/descriptors_test.rb
+++ b/hotcell-core/test/descriptors_test.rb
@@ -192,10 +192,10 @@ class DescriptorsTest < HotCellTest
     end
   end
 
-  # fd_path claims a reopen is a fresh file description at offset zero, so a tool may read the input and
-  # the supervisor's own descriptor is left where it was. On macOS opening /dev/fd/N dups the descriptor
-  # instead, so the offset is shared: the second reader resumes where the first stopped. libvips opens the
-  # path once per loader while it sniffs, which is how a HEIC file becomes unreadable there.
+  # The kernel owns this promise, and on macOS it does not keep it: opening `/dev/fd/N` dups the descriptor
+  # rather than reopening the file, so the offset is shared and the second reader resumes where the first
+  # stopped. libvips sniffs by opening the path once per candidate loader, so a HEIC file is called
+  # unreadable there.
   def test_reopening_fd_path_reads_from_zero_and_leaves_the_descriptor_alone
     with_file("source bytes") do |path|
       reading(path) do |io|

--- a/hotcell-server/lib/hot_cell/operation.rb
+++ b/hotcell-server/lib/hot_cell/operation.rb
@@ -149,7 +149,8 @@ module HotCell
     # cost gigabytes of this worker's address space, and took RLIMIT_DATA with it — arriving as a `memory`
     # verdict, which is permanent, for a document whose only crime was being noisy.
     # `pass` hands the tool a set of the worker's own descriptors — an input to read, an output to write —
-    # at their existing fd numbers, so the tool reaches them as `/dev/fd/N` (Descriptor#fd_path) and no
+    # at their existing fd numbers, so the tool reaches them at `Descriptor#fd_path` — `/dev/fd/N`, or the
+    # file's own path on macOS, where opening `/dev/fd/N` would share the worker's offset — and no
     # byte is copied onto scratch to give it a filename. A fd handed to a child this way loses its
     # close-on-exec, which is exactly the inheritance wanted, and only for these; the worker's other
     # descriptors are untouched. Passing an fd at its own number cannot collide with the stdio pipes popen3


### PR DESCRIPTION
Opening `/dev/fd/N` is a real open on Linux and a `dup(2)` on macOS, where `/dev/fd` has no procfs behind it. The shared offset meant libvips, which opens the path once per candidate loader while it sniffs, read past a HEIC file's magic bytes and reported a readable file as `unreadable`.

Answer with the filename behind the descriptor there, via `F_GETPATH`. macOS is a development platform for a cell and nothing else, so the behavior an operation sees is what has to match; how it is arrived at does not.

The first commit is the regression test, which failed on the macOS job before the fix.

ref: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10260832116