### PR TITLE
Point a worker's TMPDIR at the request's home; map MAGICK_TMPDIR in the operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ gem but are what an operator runs against their own image.
 
 * A worker sets `TMPDIR` to the request's home, and an exec'd tool inherits it. Before, nothing set it, so a library's scratch went to `/tmp` — outside the slot tree that is removed when a request ends — and a killed worker orphaned every file there until the scratch filled.
 
+### ActiveStorage::HotCell::Server
+
+#### Fixed
+
+* Every operation sets `MAGICK_TMPDIR` to the request's `TMPDIR`, so ImageMagick's pixel cache — from the `magick` the magick operations run and from the `magickload` libvips delegates to — is removed with the request, however it ends.
+
 ## v0.3.1 / 2026-09-02
 
 ### HotCell::Core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ This changelog covers five gems, which release together on the same version:
 A `Tooling` section records changes to the checks and scripts in `bin/` and `examples/`, which ship in no
 gem but are what an operator runs against their own image.
 
+## next / unreleased
+
+### HotCell::Server
+
+#### Fixed
+
+* A worker sets `TMPDIR` to the request's home, and an exec'd tool inherits it. Before, nothing set it, so a library's scratch went to `/tmp` — outside the slot tree that is removed when a request ends — and a killed worker orphaned every file there until the scratch filled.
+
 ## v0.3.1 / 2026-09-02
 
 ### HotCell::Core

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/operation.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/operation.rb
@@ -30,6 +30,15 @@ module ActiveStorage
           "tiff" => "image/tiff",
         }.freeze
 
+        # The cell describes the request's scratch as `TMPDIR`, and knows nothing about the libraries that run
+        # here. ImageMagick reads `MAGICK_TMPDIR` first, so the mapping is this gem's — for the `magick` the
+        # magick operations exec and for the `magickload` libvips delegates to in-process. Per request rather
+        # than at load: `TMPDIR` is the request's home, which is fresh every time.
+        def initialize
+          super
+          ENV["MAGICK_TMPDIR"] = ENV["TMPDIR"] if ENV.key?("TMPDIR")
+        end
+
         private
           # A caller breaking the protocol is a caller bug, not a bad document. Raising MessageError is what
           # makes the cell answer `invalid`, which is permanent and which the client raises rather than

--- a/activestorage-hotcell-server/test/magick_environment_test.rb
+++ b/activestorage-hotcell-server/test/magick_environment_test.rb
@@ -68,6 +68,22 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
     assert_operator magick_thread_resource("OMP_NUM_THREADS" => "2"), :<, magick_thread_resource({})
   end
 
+  # The cell sets `TMPDIR` to the request's home and nothing else; ImageMagick reads `MAGICK_TMPDIR`. An
+  # operation maps one to the other when it is instantiated, which is once per request — a mapping made at
+  # load would name the cell's `/tmp`, since no request has a home yet.
+  def test_an_operation_points_imagemagick_at_the_requests_tmpdir
+    output = in_a_child({}, <<~'RUBY')
+      require "json"
+      require "active_storage/hot_cell/server"
+      at_load = ENV["MAGICK_TMPDIR"]
+      ENV["TMPDIR"] = "/scratch/home-for-this-request"
+      ActiveStorage::HotCell::Server::Analyzers::Image::Magick.new
+      puts JSON.dump([ at_load, ENV["MAGICK_TMPDIR"] ])
+    RUBY
+
+    assert_equal [ nil, "/scratch/home-for-this-request" ], JSON.parse(output)
+  end
+
   private
     def magick_cli_env_under(environment)
       JSON.parse in_a_child(environment, <<~RUBY)
@@ -92,7 +108,7 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
     # The operation reads the variables at require time, so each case needs its own process. A developer's
     # own shell may hold either, so the child starts from neither and takes only what the case gives it.
     def in_a_child(environment, script)
-      environment = { "OMP_NUM_THREADS" => nil, "OMP_THREAD_LIMIT" => nil }.merge(environment)
+      environment = { "OMP_NUM_THREADS" => nil, "OMP_THREAD_LIMIT" => nil, "MAGICK_TMPDIR" => nil }.merge(environment)
       lib = File.expand_path("../lib", __dir__)
 
       IO.popen([ environment, RbConfig.ruby, "-I", lib, "-r", "bundler/setup", "-e", script ], &:read)

--- a/examples/gate
+++ b/examples/gate
@@ -59,7 +59,7 @@ SECURE = {
   cap_bound: 0,
   no_new_privs: true,
   uid: 10001,
-  tool_env: %w[ HOME LANG LC_ALL OMP_NUM_THREADS OMP_THREAD_LIMIT PATH ],
+  tool_env: %w[ HOME LANG LC_ALL OMP_NUM_THREADS OMP_THREAD_LIMIT PATH TMPDIR ],
   tool_omp: %w[ OMP_NUM_THREADS=2 OMP_THREAD_LIMIT=8 ],
 }.freeze
 

--- a/examples/lib/battery.rb
+++ b/examples/lib/battery.rb
@@ -190,7 +190,7 @@ module Examples
         assert result[:uid].to_i.positive?, "the cell runs as root or could not report its uid: #{result[:uid].inspect}"
 
         assert result[:tool_env], "the env tool could not run inside the cell"
-        extra = result[:tool_env] - %w[ HOME LANG LC_ALL OMP_NUM_THREADS OMP_THREAD_LIMIT PATH ]
+        extra = result[:tool_env] - %w[ HOME LANG LC_ALL OMP_NUM_THREADS OMP_THREAD_LIMIT PATH TMPDIR ]
         assert_equal [], extra, "an exec'd tool sees more than the written environment"
 
         # The one check here about the image rather than the runtime. An unbounded OpenMP pool takes one

--- a/hotcell-server/lib/hot_cell/operation.rb
+++ b/hotcell-server/lib/hot_cell/operation.rb
@@ -201,7 +201,7 @@ module HotCell
       # belongs to the image, which is configured to match the container's CPU quota. Without them
       # `unsetenv_others: true` would hand an exec'd tool the pool the image's bound was meant to take away.
       def tool_environment(overrides)
-        { "HOME" => ENV["HOME"], "PATH" => ENV["PATH"], "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
+        { "HOME" => ENV["HOME"], "TMPDIR" => ENV["TMPDIR"], "PATH" => ENV["PATH"], "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
           "OMP_NUM_THREADS" => ENV["OMP_NUM_THREADS"], "OMP_THREAD_LIMIT" => ENV["OMP_THREAD_LIMIT"] }
           .merge(overrides.transform_keys(&:to_s))
           .compact

--- a/hotcell-server/lib/hot_cell/test_operations.rb
+++ b/hotcell-server/lib/hot_cell/test_operations.rb
@@ -3,6 +3,7 @@
 require "digest"
 require "fcntl"
 require "fileutils"
+require "tmpdir"
 
 # Fixture operations, so the whole surface can be exercised in milliseconds, with no tool installed and no
 # container running.
@@ -470,6 +471,21 @@ module HotCell
         else
           sleep 300
         end
+      end
+    end
+
+    # Writes a file where a library writes its scratch, `Dir.tmpdir`, and leaves it there — the way ImageMagick
+    # leaves its pixel cache behind on anything but a clean exit. With `seconds:` it then blocks, so the
+    # deadline kills it mid-request.
+    class Spills < HotCell::Operation
+      operation "test.spills"
+
+      def perform(_inputs, _outputs, seconds: 0)
+        spilled = File.join(Dir.tmpdir, "spill-#{Process.pid}")
+        File.write spilled, "x"
+        sleep seconds
+
+        { spilled: spilled, home: ENV["HOME"] }
       end
     end
 

--- a/hotcell-server/lib/hot_cell/worker.rb
+++ b/hotcell-server/lib/hot_cell/worker.rb
@@ -116,6 +116,9 @@ module HotCell
           # `run`, which exits the worker — after this ensure had already reported idle `"ok"`, counting a
           # success for a request that never ran.
           ENV["HOME"] = slot.make_home
+          # The home is removed however the request ends, and `/tmp` is swept by nobody. A library's scratch
+          # goes where `TMPDIR` says, so it goes here too — whatever the library, and whatever kills the worker.
+          ENV["TMPDIR"] = ENV["HOME"]
 
           line, received = connection.receive_message
           response = if line.nil?

--- a/hotcell-server/test/cell_test.rb
+++ b/hotcell-server/test/cell_test.rb
@@ -546,6 +546,33 @@ class CellTest < HotCellServerTest
     end
   end
 
+  # ImageMagick unlinks its pixel cache only on a clean exit, and writes it where `TMPDIR` says — which
+  # nothing set, so it landed in the shared `/tmp` beside the workspace, where no reap ever looked. A slot's
+  # home is removed when the request ends, however it ends; the environment only has to point there.
+  # `TMPDIR` for the test process is the cell's own root, so a worker that inherits it rather than getting
+  # its own puts the spill exactly where production did.
+  def test_a_tools_temp_files_are_removed_with_the_home_of_a_request_that_answers
+    with_cell_spilling_into_its_root do |cell, untouched|
+      result = assert_ok(cell.call("test.spills")).result
+
+      assert_equal result[:home], File.dirname(result[:spilled]), "Dir.tmpdir is not the request's home"
+      refute_path_exists result[:spilled]
+      assert_empty Dir.children(cell.socket_root) - untouched - [ "workspace" ],
+                   "the request left something in the scratch root beside the workspace"
+    end
+  end
+
+  def test_a_tools_temp_files_are_removed_with_the_home_of_a_request_that_is_killed
+    with_cell_spilling_into_its_root(deadline: 1) do |cell, untouched|
+      assert_failed "killed", cell.call("test.spills", payload: { seconds: 30 }, timeout: 30)
+      wait_for_event cell, "worker.killed"
+
+      assert_empty Dir.children(cell.socket_root) - untouched - [ "workspace" ],
+                   "the killed worker left something in the scratch root beside the workspace"
+      assert_empty Dir.glob(File.join(cell.workspace, "0", "home-*")), "the killed request's home was not taken away"
+    end
+  end
+
   # The whole fast path, thirty times over: fork, dispatch, both of the worker's reports, the response, the
   # reap, and the slot coming back. Anything that leaves a finished worker marked in flight shows up here as a
   # spurious kill once its deadline passes.
@@ -569,4 +596,22 @@ class CellTest < HotCellServerTest
       assert_equal [ "ok", "failed" ], codes
     end
   end
+
+  private
+    # Boots a cell whose workers inherit the cell's root as their `TMPDIR`, and yields what the root holds
+    # before any request — the workspace is made by the first one — so a test can assert a request added
+    # nothing beside it.
+    def with_cell_spilling_into_its_root(**options)
+      cell = TestCell.new(concurrency: 1, **options)
+      inherited = ENV["TMPDIR"]
+      ENV["TMPDIR"] = cell.socket_root
+      cell.start
+      ENV["TMPDIR"] = inherited
+
+      yield cell, Dir.children(cell.socket_root).sort
+    ensure
+      ENV["TMPDIR"] = inherited
+      cell&.stop
+      cell&.cleanup
+    end
 end

--- a/hotcell-server/test/cell_test.rb
+++ b/hotcell-server/test/cell_test.rb
@@ -565,7 +565,8 @@ class CellTest < HotCellServerTest
   def test_a_tools_temp_files_are_removed_with_the_home_of_a_request_that_is_killed
     with_cell_spilling_into_its_root(deadline: 1) do |cell, untouched|
       assert_failed "killed", cell.call("test.spills", payload: { seconds: 30 }, timeout: 30)
-      wait_for_event cell, "worker.killed"
+      # The verdict is written before the supervisor discards the home; `worker.reaped` follows the discard.
+      refute_empty wait_for_event(cell, "worker.reaped"), "the killed worker was never reaped"
 
       assert_empty Dir.children(cell.socket_root) - untouched - [ "workspace" ],
                    "the killed worker left something in the scratch root beside the workspace"

--- a/hotcell-server/test/environment_test.rb
+++ b/hotcell-server/test/environment_test.rb
@@ -42,6 +42,20 @@ class EnvironmentTest < HotCellServerTest
     end
   end
 
+  # A tool's scratch goes where `TMPDIR` says, and the request's home is the one directory removed however
+  # the request ends.
+  def test_a_tool_writes_its_temp_files_in_the_requests_home
+    with_canary do
+      TestCell.boot do |cell|
+        seen = assert_ok(cell.call("test.environment", payload: { canary: CANARY })).result[:seen]
+
+        home = seen.grep(/\AHOME=/).first.delete_prefix("HOME=")
+
+        assert_includes seen, "TMPDIR=#{home}"
+      end
+    end
+  end
+
   def test_a_tool_gets_a_predictable_locale_so_its_output_does_not_shift_under_it
     with_canary do
       TestCell.boot do |cell|


### PR DESCRIPTION
`Worker#serve` sets `HOME` to the request's home, and that directory is removed however the request ends. Nothing set `TMPDIR`, so ImageMagick wrote its pixel cache to `/tmp`, where nothing sweeps. ImageMagick unlinks that cache only on a clean exit, so every killed worker orphaned its spill until the 4 GB scratch filled. Cause 1.1 in the [post-mortem](https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10261975276).

One commit per layer: the cell describes the shape, the operation maps it to its library.

- `hotcell-server`: set `TMPDIR` beside `HOME`, and pass it through `Operation#tool_environment`, since `run_tool` execs with `unsetenv_others: true`. `bin/conformance` enumerates the environment a tool may see, so it admits `TMPDIR`.
- `activestorage-hotcell-server`: `Operation#initialize` sets `MAGICK_TMPDIR` from `TMPDIR`, once per request. That covers the `magick` the magick operations exec and the `magickload` libvips delegates to in-process. The cell never names `MAGICK_TMPDIR`.

Tests. The cell tests boot a cell whose workers inherit the cell's own root as `TMPDIR`, so a regression puts the spill where production did. `test.spills` writes a file under `Dir.tmpdir`; the killed case blocks past a one-second deadline. Both assert the root holds nothing but the workspace afterwards; without the fix the killed case fails with `["spill-<pid>"]` left in the root. `environment_test.rb` asserts an exec'd tool sees `TMPDIR=$HOME`. `magick_environment_test.rb` asserts `MAGICK_TMPDIR` is unset after the gem loads and equals `TMPDIR` once an operation is instantiated.

Not covered here: mini_magick's `restricted_env` drops both variables from the `magick` it spawns, so `MiniMagick.cli_env` has to carry them per request. #53 does that in `MagickOperation#initialize`; whichever lands second rebases.

`VERSION` is already `0.3.2.dev` from the post-release bump, so the changelog entries open a `next / unreleased` section and there is no bump.

ref: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10270095871
