### PR TITLE
Read the ImageMagick operations' input through its descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ gem but are what an operator runs against their own image.
 
 * Every operation sets `MAGICK_TMPDIR` to the request's `TMPDIR`, so ImageMagick's pixel cache — from the `magick` the magick operations run and from the `magickload` libvips delegates to — is removed with the request, however it ends.
 
+#### Improved
+
+* The two ImageMagick operations read their input through its descriptor instead of staging a copy of it, so the operation's `file_size` no longer bounds how large an input they can read. This needs mini_magick 5.4.0 and image_processing 2.1.0, which the gemspec now requires. (#7)
+
 ## v0.3.1 / 2026-09-02
 
 ### HotCell::Core

--- a/activestorage-hotcell-server/activestorage-hotcell-server.gemspec
+++ b/activestorage-hotcell-server/activestorage-hotcell-server.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir[ "lib/**/*", "MIT-LICENSE", "README.md" ]
 
   spec.add_dependency "hotcell-server", version
-  spec.add_dependency "image_processing", ">= 2.0"
-  spec.add_dependency "mini_magick", ">= 5.2.0"
+  spec.add_dependency "image_processing", ">= 2.1.0"
+  spec.add_dependency "mini_magick", ">= 5.4.0"
   spec.add_dependency "ruby-vips", ">= 2.2.1"
 end

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/analyzers/image/magick.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/analyzers/image/magick.rb
@@ -25,7 +25,7 @@ module ActiveStorage
 
             def perform(inputs, _outputs)
               source, = inputs
-              frames = identified(source.path)
+              frames = identified(source)
               width, height, orientation = frames.first
 
               { **dimensions(width, height, orientation), pages: frames.size, animated: frames.size > 1,
@@ -36,10 +36,10 @@ module ActiveStorage
               # One `identify` run reports every frame's dimensions and orientation, where MiniMagick::Image's
               # accessors (`valid?`, `width`, `pages`) each spawn an identify of their own — four execs per
               # analysis, two of them decoding every frame.
-              def identified(path)
-                frames = MiniMagick.identify do |identify|
+              def identified(source)
+                frames = MiniMagick.identify(inherit_fds: [ source.to_io ]) do |identify|
                   identify.format "%w %h %[orientation]\n"
-                  identify << path
+                  identify << source.fd_path
                 end.lines.map(&:split)
 
                 raise MiniMagick::Invalid, "ImageMagick does not recognise this as an image" if frames.empty?

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
@@ -41,11 +41,9 @@ module ActiveStorage
       # own output — dimensions from `identify`, an exit status — which is a number and a string, not a
       # decoder. The distinction is the same one probe_media draws for ffprobe.
       #
-      # Unlike the vips operations, the input is staged onto scratch: mini_magick spawns its own `magick` and
-      # does not inherit this worker's descriptors, so an input cannot be handed to it as /dev/fd. That
-      # returns the file_size ceiling to this path — an input larger than the operation's file_size dies
-      # being staged — which the vips operations shed. Removing it means driving `magick` directly rather
-      # than through mini_magick, and is a separate enhancement.
+      # Both operations hand mini_magick the input descriptor with `inherit_fds:` and name it by its
+      # Descriptor#fd_path, so neither stages its input and neither carries the file_size ceiling the vips
+      # operations never had.
       class MagickOperation < Operation
         abstract_operation
 

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/transformers/image/magick.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/transformers/image/magick.rb
@@ -29,9 +29,17 @@ module ActiveStorage
                 ImageProcessing::MiniMagick
               end
 
-              # The staged path rather than /dev/fd; MagickOperation's comment says why.
               def source_path(source)
-                source.path
+                source.fd_path
+              end
+
+              # `source_path` names the input as the source's `/dev/fd` path, which `magick` can open only if it
+              # inherits the descriptor, so name the IO for mini_magick to put in its spawn map. Through the
+              # loader options rather than by pre-building a MiniMagick::Tool: a pre-built tool reaches
+              # ImageProcessing's `load_image` by its first branch, which drops `page`, `loader` and `geometry`
+              # without a word.
+              def source_loader_options(source)
+                { inherit_fds: [ source.to_io ] }
               end
 
               def describe(path, format)

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/transforming.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/transforming.rb
@@ -21,23 +21,40 @@ module ActiveStorage
           # it to the library, which cannot reproduce those without restating them. Output#post makes the
           # one remaining copy, out through the caller's descriptor.
           encoded = destination.path(extension: format)
-          pipeline(source_path(source), format, operations).call(destination: encoded)
+          pipeline(source, format, operations).call(destination: encoded)
           destination.adopt encoded
 
           describe destination.path, format
         end
 
         private
-          # `loader(page: 0)` first is what Rails does, and it is what stops a multi-page TIFF or a
-          # hundred-frame GIF being decoded in full to produce one thumbnail. A caller's own `loader` arrives
-          # through `apply` and merges over it, which is also what Rails does — asking for every frame is
-          # `loader: { n: -1 }`.
-          def pipeline(path, format, operations)
+          # Three `loader` calls, and the order is the point: ImageProcessing merges them key by key, so the
+          # last one to write a key wins.
+          #
+          # `page: 0` is first, as a default the caller may replace. It is what Rails does, and what stops a
+          # multi-page TIFF or a hundred-frame GIF being decoded in full to produce one thumbnail; a caller
+          # who wants every frame sends `loader: { n: -1 }` through `apply` and gets it.
+          #
+          # `source_loader_options` is last, so the caller cannot replace it.
+          def pipeline(source, format, operations)
             processor
-              .source(path)
+              .source(source_path(source))
               .loader(page: 0)
               .convert(format)
               .apply(operations_for(operations))
+              .loader(**source_loader_options(source))
+          end
+
+          # What the toolchain needs in order to reach the source at all, which is not the same question as how
+          # the image is decoded. Empty here, because `source_path` normally answers a filename and a filename
+          # needs no help. An includer whose `source_path` names something the tool cannot open on its own
+          # overrides this to supply the rest — `Transformers::Image::Magick` is the one that does.
+          #
+          # It goes last in `pipeline` because it is not the caller's to change: a payload sending
+          # `loader: { inherit_fds: [] }` would otherwise leave the source naming a descriptor the tool has no
+          # way to open.
+          def source_loader_options(_source)
+            {}
           end
 
           # What Rails validates, and no more. `combine_options` is refused because it can never be one

--- a/activestorage-hotcell-server/test/magick_analyze_image_test.rb
+++ b/activestorage-hotcell-server/test/magick_analyze_image_test.rb
@@ -26,6 +26,19 @@ class MagickAnalyzeImageTest < ActiveStorageHotCellTest
     end
   end
 
+  # Rails imposes no size limit on analysis, and neither may the cell. The input is read through its
+  # descriptor rather than copied onto scratch, so a file far larger than the operation's file_size — which
+  # bounds writes — is analyzed rather than killed while being staged.
+  def test_an_input_larger_than_the_write_limit_is_still_analyzed
+    Cell.boot(file_size: 32 * 1024) do |cell|
+      result = assert_ok(cell.call("active_storage.analyzers.image.magick",
+                                   inputs: [ fixture("large.png") ])).result
+
+      assert_equal 400, result[:width]
+      assert_equal 400, result[:height]
+    end
+  end
+
   def test_something_that_is_not_an_image_is_unreadable
     Cell.boot do |cell|
       failure = assert_failed "unreadable", cell.call("active_storage.analyzers.image.magick",

--- a/activestorage-hotcell-server/test/magick_transform_image_test.rb
+++ b/activestorage-hotcell-server/test/magick_transform_image_test.rb
@@ -67,6 +67,52 @@ class MagickTransformImageTest < ActiveStorageHotCellTest
     end
   end
 
+  # The input is read through its descriptor, not staged, so its size is not bounded by file_size — which
+  # bounds only what the operation writes. A large source downscaled to a small thumbnail succeeds under a
+  # file_size that the source alone would have blown while being copied onto scratch.
+  def test_a_large_source_downscaled_to_a_small_thumbnail_is_not_bounded_by_the_write_limit
+    Cell.boot(file_size: 64 * 1024) do |cell|
+      with_output(".png") do |destination|
+        response = cell.call "active_storage.transformers.image.magick",
+                             inputs: [ fixture("large.png") ], outputs: [ destination ],
+                             payload: { format: "png", operations: { resize_to_limit: [ 32, 32 ] } }
+
+        assert_ok response
+        assert_equal 32, identify(destination)[:width]
+      end
+    end
+  end
+
+  # A caller's own loader merges over the operation's, which is what Rails does — but not over how the input
+  # is read. Taking `inherit_fds` out of it would leave the source naming a descriptor the tool cannot open.
+  def test_a_caller_cannot_take_the_descriptor_out_of_the_loader
+    Cell.boot(file_size: 64 * 1024) do |cell|
+      with_output(".png") do |destination|
+        response = cell.call "active_storage.transformers.image.magick",
+                             inputs: [ fixture("large.png") ], outputs: [ destination ],
+                             payload: { format: "png", operations: { resize_to_limit: [ 32, 32 ],
+                                                                     loader: { inherit_fds: [] } } }
+
+        assert_ok response
+        assert_equal 32, identify(destination)[:width]
+      end
+    end
+  end
+
+  # `page: 0` reaches ImageProcessing alongside the descriptor rather than instead of it, and it is what stops
+  # a hundred-frame GIF being decoded in full to make one thumbnail.
+  def test_an_animated_source_is_flattened_to_its_first_frame_by_default
+    Cell.boot do |cell|
+      with_output(".gif") do |destination|
+        assert_ok cell.call("active_storage.transformers.image.magick",
+                            inputs: [ fixture("animated.gif") ], outputs: [ destination ],
+                            payload: { format: "gif" })
+
+        assert_equal 1, identify(destination)[:frames]
+      end
+    end
+  end
+
   def test_combine_options_is_refused
     Cell.boot do |cell|
       with_output do |destination|

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -451,8 +451,7 @@ And an operation that hands a tool a filename does not copy the input. It re-ope
 caller's. The two sides do not share a uid, so a mode `0600` file the application owns gives `EACCES`. An
 Active Storage tempfile is exactly that.
 
-Six of the eight shipped Active Storage operations hand a tool a filename. The two `magick` ones do not,
-because they stage first.
+Every shipped Active Storage operation hands a tool a filename, so this applies to all of them.
 
 **What the client does with it.** It puts each descriptor in the group and sets the mode on the way out:
 `0640` for an input, `0620` for an output. It does this through the open file rather than a path, so it


### PR DESCRIPTION
Two of the eight shipped Active Storage operations stage their input onto the worker's scratch before using it. `RLIMIT_FSIZE` bounds what a worker writes, so staging makes it bound what these two read as well, and an input larger than the operation's `file_size` dies while being copied. Rails has no such ceiling and the vips operations never had one.

It is not hypothetical. `active_storage.analyzers.image.magick` killed nine PSDs in one hour in production, each left marked `{"identified":true,"analyzed":true}` with no width, no height and no retry.

The staging was there because mini_magick spawns `magick` itself and did not inherit this worker's descriptors, so an input could not be handed to it as `/dev/fd/N`. Two upstream releases fixed that, and this is the last of the three dependent pull requests:

* [mini_magick 5.4.0](https://github.com/minimagick/minimagick/releases/tag/v5.4.0) adds `inherit_fds:` to `MiniMagick::Shell#execute`, naming IOs in `Process.spawn`'s redirect map so the child inherits them.
* [image_processing 2.1.0](https://github.com/janko/image_processing/pull/147) takes the same option on `loader`, which keeps the source a path so `page`, `loader` and `geometry` still apply to it.

Both magick operations now name their input by `Descriptor#fd_path` and hand mini_magick the descriptor behind it, so neither stages and neither carries the ceiling. The gemspec floors move with it, to 5.4.0 and 2.1.0.

The transformer reaches the option through a new `Transforming#source_loader_options` hook rather than by pre-building a `MiniMagick::Tool`. A pre-built tool takes ImageProcessing's `load_image` by its first branch, which drops `page`, `loader` and `geometry` without a word. The hook applies after the caller's own operations, because how the input is read is not theirs to change: a payload sending `loader: { inherit_fds: [] }` would otherwise leave the source naming a descriptor the tool cannot open. There is a test for that.

Verified end to end as well as in the suite: Fizzy in SaaS mode against a real cell, both magick operations clamped to `file_size: 8MB`, on released mini_magick 5.4.0 and image_processing 2.1.0.

```
big.psd: 257.5MB
  analyze: 1031.4ms
  metadata: {"identified" => true, "width" => 3000, "height" => 3000, "analyzed" => true}

big.png: 396.8MB
  variant: 5435.5ms
```

The control is released hotcell 0.3.1 on those same gems, so the only difference is this branch:

```
big.psd: 257.5MB
  analyze: 779.2ms
  metadata: {"identified" => true, "analyzed" => true}

big.png: 396.8MB
  variant: killed: fsize: Errno::EFBIG: File too large - copy_file_range
```

The PSD comes back analyzed with no dimensions and the PNG dies on `copy_file_range`, the production failure exactly.

This is the input side only. The output side cannot be handled the same way, because ImageProcessing picks its saver from the destination's extension and a `/dev/fd` path has none.

ref: https://github.com/basecamp/hotcell/issues/7

[Fix #7]
