### PR TITLE
Stop the image scan blocking on a CVE no rebuild can clear

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,12 @@ jobs:
       # with no released fix would only be able to fail every unrelated PR until upstream ships one, so they
       # are reported by the SBOM below rather than blocking here. This is a fixable-vuln gate, not a claim of
       # zero Highs.
+      #
+      # `.trivyignore.yaml` is the same admission in the other direction: a vulnerability Trivy calls fixable
+      # that nothing this repository builds can actually fix. Every entry carries a reason and an
+      # `expired_at`, and Trivy reports the finding again once that date passes, so an entry buys a review
+      # cycle rather than silence. Read that file before trusting a green run here. The SBOM step below is
+      # deliberately left without it, so the bill of materials records the image as it is.
       - name: Scan the image for fixable High and Critical vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -183,6 +189,7 @@ jobs:
           ignore-unfixed: true
           exit-code: "1"
           format: table
+          trivyignores: .trivyignore.yaml
       - name: Generate a CycloneDX SBOM of the image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,29 @@
+# Findings the image scan gate accepts, each with a reason and a date it comes back.
+#
+# Trivy drops an entry once `expired_at` passes and reports the finding again, so an entry here
+# suppresses a vulnerability for one review cycle rather than forever. Re-check the reasoning on that
+# date; do not extend one without doing so. Nothing in this file is a claim that the vulnerability is
+# absent from the image, only that the gate should not block on it yet — the same framing the scan job
+# already carries: a fixable-vuln gate, not a claim of zero Highs.
+
+vulnerabilities:
+  - id: CVE-2026-80212
+    # `resolv`, a denial of service through uncontrolled memory growth from crafted DNS responses,
+    # fixed in 0.7.2. `ruby:3.4-slim` ships 0.7.1 as a Ruby *default* gem, and the gate reads gemspec
+    # files on disk, so nothing this repository builds can clear it:
+    #
+    #   - A bundle-level `gem "resolv", ">= 0.7.2"` in the cell's Gemfile does not displace it. The
+    #     default spec stays at /usr/local/lib/ruby/gems/3.4.0/specifications/default/resolv-0.7.1.gemspec
+    #     and Trivy still reports that file. It also breaks the build outright: 0.7.2 declares
+    #     ext/win32/resolv/extconf.rb as an extension on the plain `ruby` platform, with no precompiled
+    #     variant, and the cell image carries no compiler.
+    #   - `apt-get upgrade` in the Dockerfile cannot reach it either. That line answers Debian advisories
+    #     and this is a Ruby gem.
+    #   - No published `ruby` tag carries 0.7.2 yet: 3.4-slim has 0.7.1, 4.0-slim has 0.7.0. Only a
+    #     docker-library/ruby rebuild moves it, which is what the expiry below waits for.
+    #
+    # A cell runs with `network: none` and resolves no names, so the vulnerable path is unreachable in
+    # the configuration this image is built for. That is why waiting is acceptable rather than merely
+    # convenient.
+    statement: "resolv is a default gem in ruby:3.4-slim that no bundle pin can displace, and a cell resolves no names under network: none. Revisit when docker-library/ruby rebuilds onto a Ruby carrying resolv >= 0.7.2."
+    expired_at: 2026-12-02


### PR DESCRIPTION
The `image scan and SBOM` job fails on `master` and on every open PR, including [#54](https://github.com/basecamp/hotcell/pull/54), which this unblocks. Trivy reports [`CVE-2026-80212`](https://avd.aquasec.com/nvd/cve-2026-80212) in `resolv` as a fixable High: a denial of service through uncontrolled memory growth from crafted DNS responses, fixed in 0.7.2. Nothing this repository builds can clear it.

This is not the class [#47](https://github.com/basecamp/hotcell/pull/47) fixed. That one was a Debian package the base tag had not picked up, and `apt-get upgrade` in the installed `Dockerfile` reaches it. `resolv` is a Ruby *default* gem, so that line cannot touch it, and the Debian rows in this scan are clean. The upgrade is working; it is simply the wrong instrument.

A bundle-level pin does not work either, and this is worth stating because it is the obvious next move. Two independent reasons:

```
# 1. it breaks the build: 0.7.2 declares an extension on the plain `ruby`
#    platform, with no precompiled variant, and the cell image has no compiler
Installing resolv 0.7.2 with native extensions
checking for GetNetworkParams() in -liphlpapi... *** extconf.rb failed ***
The compiler failed to generate an executable file. (RuntimeError)
ERROR: process "/bin/sh -c bundle install" did not complete successfully: exit code: 5

# 2. even with a compiler added, the scan still fails. Trivy reports per gemspec
#    file, and bundling 0.7.2 adds a file without removing the vulnerable one
hotcell/bundle/ruby/3.4.0/specifications/resolv-0.7.2.gemspec              0
usr/local/lib/ruby/gems/3.4.0/specifications/default/resolv-0.7.1.gemspec  1
Total: 1 (HIGH: 1, CRITICAL: 0)   exit 1
```

Nor does a base bump: `ruby:3.4-slim` is 3.4.10 with `resolv` 0.7.1, `ruby:3.5-slim` does not exist, and `ruby:4.0-slim` is 4.0.6 with 0.7.0, which is older. Only a [docker-library/ruby](https://github.com/docker-library/ruby) rebuild onto a Ruby carrying 0.7.2 moves this.

So the remaining honest options were to leave every unrelated PR red until upstream ships, or to say in the repository why the gate should not block on this one. Add `.trivyignore.yaml` with an entry for the CVE and pass it to the scan step with `trivyignores`. The SBOM step deliberately does not get it, so the bill of materials still records the image as it is.

The entry carries an `expired_at` of `2026-12-02`, about ninety days out. Trivy drops an expired entry and reports the finding again, so this buys one review cycle rather than silence. Confirmed against the Trivy the pinned action runs (`aquasecurity/trivy-action@ed142fd0` defaults to `v0.70.0`), with the flags CI passes, against images `bin/example-image` built:

```
no ignorefile                            Total: 1 (HIGH: 1, CRITICAL: 0), exit 1
ignorefile, expired_at 2026-12-02        no vulnerabilities, exit 0
ignorefile, expired_at backdated         Total: 1 (HIGH: 1, CRITICAL: 0), exit 1
```

The third line is the one that matters: a stale entry is not an error and does not fail closed on its own. The suppressed finding comes back and the job goes red again. That is the behaviour the date is for.

The justification is in the file rather than here, because that is where someone will read it in three months. It records that the vulnerable path is unreachable in the configuration the image is built for, since a cell runs `network: none` and resolves no names. That is why waiting is acceptable rather than merely convenient. It is not a claim the vulnerability is absent from the image, and the workflow comment says so, next to the framing [#37](https://github.com/basecamp/hotcell/pull/37) already carries: a fixable-vuln gate, not a claim of zero Highs.

No test guards this. A text assertion in `hotcell-client/test/install_test.rb` would have gone green on the `resolv` pin above while `docker build` was broken, which is the argument against it: whether a suppression works is a property of the scan, and only the scan job can see it. No `CHANGELOG.md` entry either: nothing ships in a gem, and the `Tooling` section covers `bin/` and `examples/`, not `.github/`.

`actionlint` and `zizmor` are clean on the workflow. `rake test:hotcell` passes at 411 runs and 1857 assertions, `rubocop` at 186 files with no offenses; neither is affected by this change.

ref: https://avd.aquasec.com/nvd/cve-2026-80212

🤖 Generated with [Claude Code](https://claude.com/claude-code)
