### PR TITLE
Size ImageMagick's limits to a worker's share of scratch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ gem but are what an operator runs against their own image.
 #### Fixed
 
 * Every operation sets `MAGICK_TMPDIR` to the request's `TMPDIR`, so ImageMagick's pixel cache — from the `magick` the magick operations run and from the `magickload` libvips delegates to — is removed with the request, however it ends.
+* `MagickOperation` forwards the worker's `MAGICK_*_LIMIT`, `TMPDIR` and `MAGICK_TMPDIR` to the `magick` it spawns, read per request. `MiniMagick.restricted_env` had dropped them along with the rest of the environment, so an image's `MAGICK_DISK_LIMIT` bounded ImageMagick inside libvips and not the `magick` behind `analyzers.image.magick` and `transformers.image.magick`, which ran under ImageMagick's defaults — the host's RAM and an unbounded disk — and the request's `TMPDIR` above never reached it.
 
 ## v0.3.1 / 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ gem but are what an operator runs against their own image.
 * Every operation sets `MAGICK_TMPDIR` to the request's `TMPDIR`, so ImageMagick's pixel cache — from the `magick` the magick operations run and from the `magickload` libvips delegates to — is removed with the request, however it ends.
 * `MagickOperation` forwards the worker's `MAGICK_*_LIMIT`, `TMPDIR` and `MAGICK_TMPDIR` to the `magick` it spawns, read per request. `MiniMagick.restricted_env` had dropped them along with the rest of the environment, so an image's `MAGICK_DISK_LIMIT` bounded ImageMagick inside libvips and not the `magick` behind `analyzers.image.magick` and `transformers.image.magick`, which ran under ImageMagick's defaults — the host's RAM and an unbounded disk — and the request's `TMPDIR` above never reached it.
 
+### Tooling
+
+#### Added
+
+* The installed `Dockerfile` sets `MAGICK_MEMORY_LIMIT`, `MAGICK_DISK_LIMIT` and `MAGICK_MAP_LIMIT`, pixel cache budgets sized within one worker's share of the container's memory and scratch; `docs/DEPLOYMENT.md` derives the numbers. Without a disk limit one layered PSD fills the scratch shared by every worker, and a full scratch fails every file that arrives while it is full.
+
 ## v0.3.1 / 2026-09-02
 
 ### HotCell::Core

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
@@ -8,29 +8,6 @@ require "active_storage/hot_cell/server/operation"
 # toolchains' loads in the same place is what makes a single cell carrying both legible.
 require "image_processing/mini_magick"
 
-# Invariant 9: a tool sees only the environment its operation wrote for it. `Operation#run_tool` holds it
-# with `unsetenv_others: true`, and these operations do not use it — mini_magick spawns `magick` itself.
-# `MiniMagick.restricted_env` is `false` by default, and with it false mini_magick calls
-# `Open3.popen3({}, *command, unsetenv_others: false)`, so `magick` inherited this worker's whole
-# environment. `bin/conformance` did not catch it, because its environment check drives an operation that
-# goes through `run_tool`.
-#
-# `cli_env` names the locale for the reason `tool_environment` does: a tool's output must not shift under
-# it. mini_magick passes `HOME`, `PATH` and `LANG` and does not pass `LC_ALL`, so both go here.
-#
-# Set at require time rather than in `before_worker_boot`, so that the binary lookup this require performs
-# is covered too. Note what this is: mini_magick filters the environment it was given, where `run_tool`
-# writes a fresh one. Driving `magick` directly would make it ours, and that is the separate enhancement
-# this class already names.
-#
-# The OpenMP variables come from the cell's environment rather than being named here: the number belongs
-# to the image, which is configured to match the container's CPU quota. Without them the restriction would
-# hand `magick` the pool the image's bound was meant to take away. `run_tool` carries the same pair.
-MiniMagick.restricted_env = true
-MiniMagick.cli_env = { "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
-                       "OMP_NUM_THREADS" => ENV["OMP_NUM_THREADS"],
-                       "OMP_THREAD_LIMIT" => ENV["OMP_THREAD_LIMIT"] }.compact
-
 module ActiveStorage
   module HotCell
     module Server
@@ -48,6 +25,40 @@ module ActiveStorage
       # than through mini_magick, and is a separate enhancement.
       class MagickOperation < Operation
         abstract_operation
+
+        # Invariant 9: a tool sees only the environment its operation wrote for it. `Operation#run_tool` holds
+        # it with `unsetenv_others: true`, and these operations do not use it — mini_magick spawns `magick`
+        # itself. `MiniMagick.restricted_env` is `false` by default, and with it false mini_magick calls
+        # `Open3.popen3({}, *command, unsetenv_others: false)`, so `magick` inherited this worker's whole
+        # environment. `bin/conformance` did not catch it, because its environment check drives an operation
+        # that goes through `run_tool`. Note what this is: mini_magick filters the environment it was given,
+        # where `run_tool` writes a fresh one. Driving `magick` directly would make it ours, and that is the
+        # separate enhancement this class already names.
+        #
+        # The locale is named for the reason `tool_environment` names it: a tool's output must not shift under
+        # it. mini_magick passes `HOME`, `PATH` and `LANG` and does not pass `LC_ALL`, so both go here.
+        #
+        # Everything else comes from the worker's environment rather than being named here. The OpenMP pair
+        # belongs to the image, which is configured to match the container's CPU quota. ImageMagick's own
+        # resource ceilings, `MAGICK_DISK_LIMIT` and its siblings, are read from its environment as it loads
+        # and the image sets them to a worker's share of the scratch; without them `magick` runs under
+        # ImageMagick's defaults, the host's RAM and an unbounded disk. `TMPDIR` and `MAGICK_TMPDIR` are where
+        # it spills that cache: the worker sets the first to the request's home after the fork and
+        # `Operation#initialize` maps the second from it — which is why this is read per request, after
+        # `super`, and not once at require: a hash built then hands `magick` the supervisor's `/tmp`, where
+        # nothing sweeps what a killed worker leaves.
+        def self.cli_env
+          { "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
+            "OMP_NUM_THREADS" => ENV["OMP_NUM_THREADS"], "OMP_THREAD_LIMIT" => ENV["OMP_THREAD_LIMIT"],
+            "TMPDIR" => ENV["TMPDIR"], "MAGICK_TMPDIR" => ENV["MAGICK_TMPDIR"] }
+            .merge(ENV.select { |name, _| name.match?(/\AMAGICK_\w+_LIMIT\z/) })
+            .compact
+        end
+
+        def initialize
+          super
+          MiniMagick.cli_env = self.class.cli_env
+        end
 
         # MiniMagick::Error is how mini_magick reports a `magick` that exited non-zero — the common shape of an
         # input it cannot decode. MiniMagick::Invalid is an input `identify` rejects outright.
@@ -71,3 +82,7 @@ module ActiveStorage
     end
   end
 end
+
+# Also at require time, so that the binary lookup the require above performs is covered too.
+MiniMagick.restricted_env = true
+MiniMagick.cli_env = ActiveStorage::HotCell::Server::MagickOperation.cli_env

--- a/activestorage-hotcell-server/test/magick_environment_test.rb
+++ b/activestorage-hotcell-server/test/magick_environment_test.rb
@@ -17,6 +17,9 @@ require "etc"
 # does not read it decodes normally. The cell is forked from this process, so the variable reaches the
 # worker.
 class MagickEnvironmentTest < ActiveStorageHotCellTest
+  UNSET = %w[ OMP_NUM_THREADS OMP_THREAD_LIMIT MAGICK_DISK_LIMIT MAGICK_MAP_LIMIT TMPDIR MAGICK_TMPDIR ]
+    .to_h { |name| [ name, nil ] }
+
   def test_magick_does_not_inherit_the_workers_environment
     with_refusing_policy_in_the_environment do
       Cell.boot do |cell|
@@ -46,6 +49,37 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
 
     assert_equal bound, magick_cli_env_under(bound)
     assert_empty magick_cli_env_under({}), "the cell invented a bound of its own"
+  end
+
+  # ImageMagick reads its resource ceilings out of its own environment, and the image is where they are set,
+  # so the restriction above would otherwise hand `magick` ImageMagick's defaults: the host's RAM and an
+  # unbounded disk.
+  def test_the_cli_env_carries_the_images_imagemagick_resource_limits
+    limits = { "MAGICK_DISK_LIMIT" => "768MiB", "MAGICK_MAP_LIMIT" => "768MiB" }
+
+    assert_equal limits, magick_cli_env_under(limits, *limits.keys)
+    assert_empty magick_cli_env_under({}, *limits.keys), "the cell invented a limit of its own"
+  end
+
+  def test_mini_magick_hands_the_resource_limits_to_magick
+    skip "ImageMagick is not installed" unless magick_installed?
+
+    assert_equal "768MiB", magick_resource_through_mini_magick("Disk", "MAGICK_DISK_LIMIT" => "768MiB")
+  end
+
+  # The worker sets TMPDIR to the request's home after the fork and `Operation#initialize` maps MAGICK_TMPDIR
+  # from it, so a hash built when the operation was required would send ImageMagick's spill to the
+  # supervisor's /tmp, where nothing sweeps it.
+  def test_the_cli_env_follows_the_requests_tmpdir
+    where = { "TMPDIR" => "/tmp/request-home", "MAGICK_TMPDIR" => "/tmp/request-home" }
+
+    assert_equal where, JSON.parse(in_a_child({}, <<~RUBY))
+      require "json"
+      require "active_storage/hot_cell/server/analyzers/image/magick"
+      ENV["TMPDIR"] = "/tmp/request-home"
+      ActiveStorage::HotCell::Server::Analyzers::Image::Magick.new
+      puts JSON.dump(MiniMagick.cli_env.slice("TMPDIR", "MAGICK_TMPDIR"))
+    RUBY
   end
 
   # mini_magick, rather than our hash: it is unbounded in the gemspec, and a version that stopped merging
@@ -85,11 +119,13 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
   end
 
   private
-    def magick_cli_env_under(environment)
+    def magick_cli_env_under(environment, *names)
+      names = %w[ OMP_NUM_THREADS OMP_THREAD_LIMIT ] if names.empty?
+
       JSON.parse in_a_child(environment, <<~RUBY)
         require "json"
         require "active_storage/hot_cell/server/magick_operation"
-        puts JSON.dump(MiniMagick.cli_env.slice("OMP_NUM_THREADS", "OMP_THREAD_LIMIT"))
+        puts JSON.dump(MiniMagick.cli_env.slice(*#{names.inspect}))
       RUBY
     end
 
@@ -97,18 +133,20 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
     # merges into that child is what the assertion is about. Nothing here rescues, so a child that cannot
     # run fails the test rather than reading as a bound of zero.
     def magick_threads_through_mini_magick(environment)
-      output = in_a_child(environment, <<~'RUBY')
-        require "active_storage/hot_cell/server/magick_operation"
-        print MiniMagick.convert { |command| command.list "resource" }[/Thread: (\d+)/, 1]
-      RUBY
+      Integer(magick_resource_through_mini_magick("Thread", environment))
+    end
 
-      Integer(output)
+    def magick_resource_through_mini_magick(resource, environment)
+      in_a_child(environment, <<~RUBY)
+        require "active_storage/hot_cell/server/magick_operation"
+        print MiniMagick.convert { |command| command.list "resource" }[/#{resource}: (\\S+)/, 1]
+      RUBY
     end
 
     # The operation reads the variables at require time, so each case needs its own process. A developer's
-    # own shell may hold either, so the child starts from neither and takes only what the case gives it.
+    # own shell may hold any of them, so the child starts from none and takes only what the case gives it.
     def in_a_child(environment, script)
-      environment = { "OMP_NUM_THREADS" => nil, "OMP_THREAD_LIMIT" => nil, "MAGICK_TMPDIR" => nil }.merge(environment)
+      environment = UNSET.merge(environment)
       lib = File.expand_path("../lib", __dir__)
 
       IO.popen([ environment, RbConfig.ruby, "-I", lib, "-r", "bundler/setup", "-e", script ], &:read)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -223,6 +223,9 @@ Environment variables. The image sets all of them, so set one only to override i
 | `HOME` | `/tmp` | Bundler needs one, and the cell's user has no home directory. A worker replaces it with a directory made for the request and removed with it. |
 | `OMP_NUM_THREADS` | `2` | The OpenMP pool size libvips and ImageMagick use. Match it to `cpus`. See "Bound the OpenMP thread pools". |
 | `OMP_THREAD_LIMIT` | `8` | The ceiling on that pool, including a library that raises the count itself. |
+| `MAGICK_MEMORY_LIMIT` | `256MiB` | Heap for ImageMagick's pixel caches, all frames together; a cache that does not fit goes to scratch whole. `(memory − tmpfs) ÷ concurrency`, less the worker's own footprint. See "Size ImageMagick's pixel cache limits". |
+| `MAGICK_DISK_LIMIT` | `16MiB` | Scratch for the caches that missed memory, all frames together; past it the file is `unreadable`. `min(file_size, (scratch − reserve) ÷ concurrency − staged files × file_size)`. |
+| `MAGICK_MAP_LIMIT` | `16MiB` | How much of that spill is memory-mapped rather than read with plain I/O. Same files, same scratch: set it equal to `MAGICK_DISK_LIMIT`. |
 
 ### Bound the OpenMP thread pools
 
@@ -264,6 +267,109 @@ own.
 To verify a built image, write a GIF inside it and count `/proc/self/task` during the write. GIF is the
 cheapest probe: it is the only common output format that quantizes, and quantization is where the threads
 appear. Unbounded, the count tracks the visible cores; bounded, it stays at the limit.
+
+### Size ImageMagick's pixel cache limits
+
+**Set `MAGICK_MEMORY_LIMIT`, `MAGICK_DISK_LIMIT` and `MAGICK_MAP_LIMIT` in the image.** The installed
+`Dockerfile` sets all three, sized for the worked example below. `hotcell:install` leaves an existing
+`Dockerfile` untouched, so add them by hand to a cell installed before this and rebuild its image. The
+scaffold installs no ImageMagick; the numbers are for whichever build your operations bring, and this
+section is how to recompute them for your accessory.
+
+**What ImageMagick does with them.** ImageMagick decodes every frame of an image into a *pixel cache*: an
+uncompressed copy, `width × height × bytes per pixel`. Bytes per pixel comes from the build: ImageMagick 6
+Q16, which Basecamp's cell image carries, stores four 16-bit channels, so 8, or 10 when the image also
+carries a black or colormap-index channel (CMYK, palette). ImageMagick 7 stores 2 bytes a channel, or 4 in
+an HDRI build, for the channels the image has. So a 4096 × 4096 RGB image is 128MiB at 8 bytes a pixel before
+anything is done to it, and a layered PSD holds one cache per layer, all at once. A transform holds the
+source and the result at the same time, and some operations hold intermediates as well. `-debug cache`
+prints the size of each cache as it opens. Where a cache goes is decided by three limits
+([resources](https://imagemagick.org/script/resources.php)), and all three count the process's caches
+together, not one at a time:
+
+1. `MAGICK_MEMORY_LIMIT` — heap. A new cache goes here while the caches already open plus this one fit.
+2. When it does not fit, the whole cache goes to a file under `MAGICK_TMPDIR` instead — the request's
+   directory on scratch — and counts against `MAGICK_DISK_LIMIT`. `MAGICK_MAP_LIMIT` decides whether that
+   file is memory-mapped or read with plain I/O; it is the same file on the same scratch either way, so
+   there is no reason to set it above `MAGICK_DISK_LIMIT`.
+3. When a cache does not fit under `MAGICK_DISK_LIMIT` either, ImageMagick fails with
+   `cache resources exhausted`. The cell reports that as `unreadable`: a permanent verdict on the file.
+
+A cache never straddles a limit: it goes into memory whole or to disk whole. Two consequences worth
+stating plainly. One frame is readable only if it fits under `MAGICK_MEMORY_LIMIT` or under
+`MAGICK_DISK_LIMIT` on its own, so the larger of the two is the largest single frame the cell decodes.
+A multi-frame file is readable only if all its frames together fit under both added together.
+
+ImageMagick's own defaults are most of the host's RAM and an unbounded disk, and `policy.xml` in the
+image is a ceiling the environment can lower and never raise; `identify -list resource` shows what a
+build ends up with. Check `identify -list policy` too: a `temporary-path` policy overrides `MAGICK_TMPDIR`
+and would put the spill outside the request's directory. Basecamp's current image has it commented out.
+`MAGICK_AREA_LIMIT` is not set: an image over `area` is sent to disk rather than memory, not refused, so it
+only moves step 1's line, and the memory limit already draws it.
+
+**Why the disk limit exists.** Without it, step 2 has no ceiling: a layered PSD writes one cache file per
+layer until the scratch is full. `file_size` is `RLIMIT_FSIZE`, a limit on each file, and cannot bound
+the sum. A full scratch fails every image that arrives while it is full, which is what happened to
+Basecamp on 2026-09-01 — see "Making the numbers agree".
+
+**The arithmetic, on the worked example.** Container `memory: 2g`, tmpfs `size=512m`, `concurrency: 4`,
+and the image operations' `file_size: 48MB`. Every "MB" here is `1024²` bytes, as `config.rb` writes it.
+
+*Scratch.* The disk limit counts ImageMagick's cache files and nothing else, and they are not the only
+files on the tmpfs: each request's directory holds its staged input and its output, and libvips writes
+its own temporary files under `TMPDIR` for an image above its disc threshold. So keep a reserve out of
+the tmpfs first, then split the rest four ways. The `transformers.image.magick` operation stages its input
+(mini_magick cannot take a descriptor) and writes its output, each up to `file_size`, so 96MiB of a
+worker's share is spoken for before ImageMagick spills anything. What is left is the disk limit. It must
+also stay at or under `file_size`: `RLIMIT_FSIZE` bounds each cache file, and a disk limit above it would
+let the kernel's per-file limit fire before ImageMagick's own check does, so the refusal would come from a
+different place with a different error. The 64MiB reserve is an illustrative margin; size yours from the
+peak of everything else on the tmpfs with every worker busy, not counting the staged files the formula
+already subtracts:
+
+    available         = (scratch − reserve) ÷ concurrency − staged files × file_size
+                      = (512MiB − 64MiB) ÷ 4 − 2 × 48MiB = 112MiB − 96MiB = 16MiB
+    MAGICK_DISK_LIMIT = min(file_size, available) = min(48MiB, 16MiB) = 16MiB
+    MAGICK_MAP_LIMIT  = MAGICK_DISK_LIMIT = 16MiB
+
+`available` must come out at zero or more. Below zero the staged files alone do not fit the share, so
+enlarge scratch or lower `file_size` or `concurrency`; do not write a negative number, which ImageMagick
+reads as a huge one. Four workers each at that peak at once take `4 × (96 + 16) = 448MiB`, and the 64MiB
+reserve is what everything else on the tmpfs has.
+
+*Memory.* The container's `memory` is a cgroup limit, and on the default accessory the tmpfs is charged to
+it byte for byte — see "Where scratch lives" — so the processes get what the scratch cannot take:
+
+    for processes         = memory − tmpfs = 2048MiB − 512MiB = 1536MiB
+    per worker            = 1536MiB ÷ 4 = 384MiB
+    a worker's own cost   ≈ 70MiB resident with libvips and mini_magick loaded, plus about 12MiB for the
+                            `magick` it spawns (measured with the gems loaded and in Basecamp's cell image;
+                            measure yours as `VmRSS` in `/proc/<pid>/status` of a worker that has served a
+                            request)
+    ceiling               = 384MiB − 82MiB = 302MiB
+    MAGICK_MEMORY_LIMIT   = 256MiB
+
+256MiB is the round number under that ceiling. The 46MiB a worker it leaves is for the supervisor and
+for what the tools allocate outside the pixel cache, which the limit does not count: libvips' own
+buffers, coder scratch, and any algorithm ImageMagick documents as not honouring its limits. Four workers
+at the limit and a full tmpfs are 4 × 338 + 512 = 1864MiB against the 2048MiB cgroup. Past the cgroup the
+kernel picks a victim in the cell and sends `SIGKILL` with no diagnostic. The cell's own `memory`
+(`RLIMIT_DATA`, 1280MB for the transformer) is inherited by the `magick` child and sits well above this,
+so it is not what stops a large image here.
+
+*What that buys.* At 8 bytes a pixel, 256MiB holds 33.5 million pixels of RGB(A) — 5792 × 5792, or 8192 ×
+4096 — or 26.8 million with an index channel. That is the sum of every cache open at once: a same-size
+transform needs two of them, a thumbnail little more than the source, an operation with intermediates
+more. 16MiB on disk adds nothing to a single frame, since a frame that misses memory needs to
+fit on disk on its own; the caches of a multi-frame file may total 272MiB. Anything larger is `unreadable`
+once ImageMagick reaches the cache, with an empty scratch, instead of a full scratch and a dead cell. The
+2026-09-01 PSD had a 10GiB disk limit against a 4G mount, so it was never refused.
+
+**Recompute all three** when `memory`, the tmpfs `size=`, `concurrency`, the reserve or the image
+operations' `file_size` move, and read the pixel counts again when the ImageMagick build's bytes per
+pixel differ. The limits are per ImageMagick process, not per worker: an operation that ran two at once
+would get two allowances. The formulas are repeated in the
+`Dockerfile` next to the values.
 
 ### Sizing the numbers
 
@@ -503,7 +609,7 @@ matching, storing or rendering are all places these values raise.
 
 ## Making the numbers agree
 
-Nothing checks these three for you.
+Nothing checks these for you.
 
 - The client's `timeout` must be more than the cell's `answer_within`, which is
   `queue_wait + deadline + 1`. Below it, a saturated cell reaches the caller as a transport failure
@@ -513,6 +619,11 @@ Nothing checks these three for you.
 - `file_size × concurrency` must fit scratch. Above it, concurrent workers fill it and requests fail
   with `ENOSPC` instead of with a limit verdict. On the default accessory scratch is the tmpfs, and its
   `size=` is the number to fit.
+- `MAGICK_DISK_LIMIT` must fit a worker's share of scratch beside the files that worker stages there,
+  and `MAGICK_MEMORY_LIMIT` must fit a worker's share of the container's `memory` after the tmpfs is
+  taken out. Larger values eat the reserves, and once those are gone a busy cell gets `ENOSPC` across
+  every worker or a cgroup kill instead of one `unreadable`. The arithmetic is under "Size ImageMagick's
+  pixel cache limits".
 
 Three things are fixed and cannot be configured: the one-second grace between the signal to a worker and
 the kill of its process group, the absence of an `RLIMIT_CPU`, and the socket file mode.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -223,8 +223,8 @@ Environment variables. The image sets all of them, so set one only to override i
 | `HOME` | `/tmp` | Bundler needs one, and the cell's user has no home directory. A worker replaces it with a directory made for the request and removed with it. |
 | `OMP_NUM_THREADS` | `2` | The OpenMP pool size libvips and ImageMagick use. Match it to `cpus`. See "Bound the OpenMP thread pools". |
 | `OMP_THREAD_LIMIT` | `8` | The ceiling on that pool, including a library that raises the count itself. |
-| `MAGICK_MEMORY_LIMIT` | `256MiB` | Heap for ImageMagick's pixel caches, all frames together; a cache that does not fit goes to scratch whole. `(memory − tmpfs) ÷ concurrency`, less the worker's own footprint. See "Size ImageMagick's pixel cache limits". |
-| `MAGICK_DISK_LIMIT` | `16MiB` | Scratch for the caches that missed memory, all frames together; past it the file is `unreadable`. `min(file_size, (scratch − reserve) ÷ concurrency − staged files × file_size)`. |
+| `MAGICK_MEMORY_LIMIT` | `256MiB` | Heap for ImageMagick's pixel caches, all frames together; a cache that does not fit goes to scratch whole. This is what bounds a single frame. `(memory − tmpfs) ÷ concurrency`, less the worker's own footprint, and under every reaching operation's `memory`. See "Size ImageMagick's pixel cache limits". |
+| `MAGICK_DISK_LIMIT` | `16MiB` | Scratch for the caches that missed memory, all frames together; past it the file is `unreadable`. `(scratch − reserve) ÷ concurrency − staged files × file_size`, worked per operation and set to the smallest result. Not clamped to `file_size`: that bounds each file, this bounds their sum. |
 | `MAGICK_MAP_LIMIT` | `16MiB` | How much of that spill is memory-mapped rather than read with plain I/O. Same files, same scratch: set it equal to `MAGICK_DISK_LIMIT`. |
 
 ### Bound the OpenMP thread pools
@@ -300,6 +300,24 @@ stating plainly. One frame is readable only if it fits under `MAGICK_MEMORY_LIMI
 `MAGICK_DISK_LIMIT` on its own, so the larger of the two is the largest single frame the cell decodes.
 A multi-frame file is readable only if all its frames together fit under both added together.
 
+**Which of your operations these limits reach.** ImageMagick runs in a cell two ways, and the environment
+reaches both:
+
+- **As a `magick` child**, which mini_magick spawns for `analyzers.image.magick` and
+  `transformers.image.magick`. The cache files are that process's own, on top of whatever the operation
+  stages.
+- **In the worker itself**, when libvips delegates a format it does not decode — PSD, BMP, ICO — to
+  `magickload`. Here ImageMagick's pixel cache *is* that request's decode, so its spill files stand in
+  for the temporary libvips would otherwise have written above `VIPS_DISC_THRESHOLD`, rather than
+  arriving on top of it. An application that reopens `VipsForeignLoadMagick` is in this case even when
+  it loads no `*.image.magick` operation at all — and it is the case the 2026-09-01 incident was in.
+
+This matters because the arithmetic below is **per operation**, while the environment is one setting for
+the whole image. Work each operation that can reach ImageMagick separately — each has its own `file_size`,
+its own `memory`, and its own count of files staged on scratch — and set the environment to the smallest
+result. The worked example below has a single profile, so it never has to make the choice; a cell that
+serves several does.
+
 ImageMagick's own defaults are most of the host's RAM and an unbounded disk, and `policy.xml` in the
 image is a ceiling the environment can lower and never raise; `identify -list resource` shows what a
 build ends up with. Check `identify -list policy` too: a `temporary-path` policy overrides `MAGICK_TMPDIR`
@@ -320,25 +338,45 @@ files on the tmpfs: each request's directory holds its staged input and its outp
 its own temporary files under `TMPDIR` for an image above its disc threshold. So keep a reserve out of
 the tmpfs first, then split the rest four ways. The `transformers.image.magick` operation stages its input
 (mini_magick cannot take a descriptor) and writes its output, each up to `file_size`, so 96MiB of a
-worker's share is spoken for before ImageMagick spills anything. What is left is the disk limit. It must
-also stay at or under `file_size`: `RLIMIT_FSIZE` bounds each cache file, and a disk limit above it would
-let the kernel's per-file limit fire before ImageMagick's own check does, so the refusal would come from a
-different place with a different error. The 64MiB reserve is an illustrative margin; size yours from the
-peak of everything else on the tmpfs with every worker busy, not counting the staged files the formula
-already subtracts:
+worker's share is spoken for before ImageMagick spills anything. What is left is the disk limit. The
+64MiB reserve is an illustrative margin; size yours from the peak of everything else on the tmpfs with
+every worker busy — not counting the staged files the formula already subtracts, and not counting
+libvips' own temporary for an operation whose ImageMagick runs under `magickload`, where the cache files
+replace it rather than adding to it:
 
-    available         = (scratch − reserve) ÷ concurrency − staged files × file_size
+    MAGICK_DISK_LIMIT = (scratch − reserve) ÷ concurrency − staged files × file_size
                       = (512MiB − 64MiB) ÷ 4 − 2 × 48MiB = 112MiB − 96MiB = 16MiB
-    MAGICK_DISK_LIMIT = min(file_size, available) = min(48MiB, 16MiB) = 16MiB
     MAGICK_MAP_LIMIT  = MAGICK_DISK_LIMIT = 16MiB
 
-`available` must come out at zero or more. Below zero the staged files alone do not fit the share, so
-enlarge scratch or lower `file_size` or `concurrency`; do not write a negative number, which ImageMagick
-reads as a huge one. Four workers each at that peak at once take `4 × (96 + 16) = 448MiB`, and the 64MiB
-reserve is what everything else on the tmpfs has.
+It must come out at zero or more. Below zero the staged files alone do not fit the share, so enlarge
+scratch or lower `file_size` or `concurrency`; do not write a negative number, which ImageMagick reads as
+a huge one. Four workers each at that peak at once take `4 × (96 + 16) = 448MiB`, and the 64MiB reserve
+is what everything else on the tmpfs has.
+
+**`file_size` is not a ceiling on this.** The two bound different things and neither substitutes for the
+other: `MAGICK_DISK_LIMIT` bounds the *sum* of the cache files a process has open, and `file_size` is
+`RLIMIT_FSIZE`, which bounds *each file on its own*. A twenty-layer PSD writing twenty 40MiB caches
+totals 800MiB without any single file coming near a 48MiB `RLIMIT_FSIZE` — which is the runaway this
+limit exists to stop, happening entirely below `file_size`. Clamping the disk limit to `file_size` would
+therefore not make it safer, and on a generous scratch it throws most of the share away.
+
+What `file_size` does decide is *which* error a caller sees. When the disk limit is above it, a single
+cache file that passes `RLIMIT_FSIZE` first earns an `fsize` kill rather than
+`cache resources exhausted` — the same class of verdict, permanent and about the file, reported from a
+different place. Where a cell's operations carry different `file_size` values, expect that on the ones
+below the limit, and say so where the verdict is read.
+
+**Read the result as a residual, not as a judgement about images.** What bounds a single frame is
+`MAGICK_MEMORY_LIMIT`, because a cache that misses memory must fit the disk limit *on its own*; the disk
+limit only adds capacity for the frames of a multi-frame file. So a small number here does not mean
+ordinary images will fail — the worked example's 16MiB refuses nothing a 256MiB memory limit admits. It
+means scratch is nearly spoken for by `staged files × file_size × concurrency`, and the lever is the
+scratch, the `file_size` or the `concurrency`, not this variable.
 
 *Memory.* The container's `memory` is a cgroup limit, and on the default accessory the tmpfs is charged to
-it byte for byte — see "Where scratch lives" — so the processes get what the scratch cannot take:
+it byte for byte — see "Where scratch lives" — so the processes get what the scratch cannot take. The
+tmpfs term is the tmpfs layout's alone: on a named volume or a host mount, scratch is disk and the
+processes get the whole of `memory`.
 
     for processes         = memory − tmpfs = 2048MiB − 512MiB = 1536MiB
     per worker            = 1536MiB ÷ 4 = 384MiB
@@ -349,13 +387,23 @@ it byte for byte — see "Where scratch lives" — so the processes get what the
     ceiling               = 384MiB − 82MiB = 302MiB
     MAGICK_MEMORY_LIMIT   = 256MiB
 
-256MiB is the round number under that ceiling. The 46MiB a worker it leaves is for the supervisor and
-for what the tools allocate outside the pixel cache, which the limit does not count: libvips' own
-buffers, coder scratch, and any algorithm ImageMagick documents as not honouring its limits. Four workers
-at the limit and a full tmpfs are 4 × 338 + 512 = 1864MiB against the 2048MiB cgroup. Past the cgroup the
-kernel picks a victim in the cell and sends `SIGKILL` with no diagnostic. The cell's own `memory`
-(`RLIMIT_DATA`, 1280MB for the transformer) is inherited by the `magick` child and sits well above this,
-so it is not what stops a large image here.
+256MiB is the round number under that ceiling — round down far enough to leave the worker something,
+which here is 46MiB. That 46MiB is for the supervisor and for what the tools allocate outside the pixel
+cache, which the limit does not count: libvips' own buffers, coder scratch, and any algorithm ImageMagick
+documents as not honouring its limits. Four workers at the limit and a full tmpfs are
+4 × 338 + 512 = 1864MiB against the 2048MiB cgroup. Past the cgroup the kernel picks a victim in the cell
+and sends `SIGKILL` with no diagnostic.
+
+**Check it against the operation's own `memory`, which is the second ceiling.** A cache on the heap is
+private anonymous memory, so the operation's `memory` — `RLIMIT_DATA` — charges it, whether ImageMagick
+is the `magick` child that inherits the limit or `magickload` inside the worker that owns it. So
+`MAGICK_MEMORY_LIMIT` plus the worker's own footprint has to sit under the `memory` of every operation
+that can reach ImageMagick, with room for what that operation allocates besides. Above it the limit stops
+doing its job: the process dies on `RLIMIT_DATA` — as a `killed`/`crashed` verdict, or as libgomp's
+unrecoverable `EAGAIN` on a thread it cannot create — instead of refusing the frame with
+`cache resources exhausted`. One is transient and retried against a limit that fails it again; the other
+is a verdict on the file. In the worked example the transformer's 1280MB sits well above 256MiB + 82MiB,
+so it never fires first. Recheck this whenever either number moves.
 
 *What that buys.* At 8 bytes a pixel, 256MiB holds 33.5 million pixels of RGB(A) — 5792 × 5792, or 8192 ×
 4096 — or 26.8 million with an index channel. That is the sum of every cache open at once: a same-size
@@ -624,6 +672,12 @@ Nothing checks these for you.
   taken out. Larger values eat the reserves, and once those are gone a busy cell gets `ENOSPC` across
   every worker or a cgroup kill instead of one `unreadable`. The arithmetic is under "Size ImageMagick's
   pixel cache limits".
+- `MAGICK_MEMORY_LIMIT` plus the worker's footprint must also fit under the `memory` of every operation
+  that can reach ImageMagick. Above it the pixel cache dies on `RLIMIT_DATA` — a transient `killed`,
+  retried against a limit that fails it again — instead of being refused as `unreadable`.
+- Both are one environment for the whole image, while the arithmetic that sizes them is per operation.
+  A cell whose operations carry different `file_size` or `memory` values takes the smallest result, and
+  gets an `fsize` kill rather than `cache resources exhausted` on the operations below it.
 
 Three things are fixed and cannot be configured: the one-second grace between the signal to a worker and
 the kill of its process group, the absence of an `RLIMIT_CPU`, and the socket file mode.
@@ -761,4 +815,8 @@ Two things do not change on any layout:
 
 - `HOTCELL_WORKSPACE` keeps its default. It lives under `Dir.tmpdir`, and the server treats scratch as a
   plain directory without ever checking the filesystem type.
-- A full scratch still reaches the caller as `failed`, which is transient, exactly as a full tmpfs did.
+- A full scratch reaches the caller the same way it did on a tmpfs — which is not one way. The `ENOSPC`
+  that staging and `run_tool` raise falls through to `failed`, which is transient. A write that fails
+  *inside* libvips does not: it surfaces as `Vips::Error`, which `VipsOperation` declares `unreadable`,
+  and that is a permanent verdict on a customer's file for our disk. That asymmetry is why the scratch is
+  worth a reserve — see "Size ImageMagick's pixel cache limits".

--- a/hotcell-client/lib/hot_cell/install/Dockerfile.tt
+++ b/hotcell-client/lib/hot_cell/install/Dockerfile.tt
@@ -51,6 +51,25 @@ ENV HOME=/tmp \
     HOTCELL_OPERATIONS=/hotcell/operations \
     HOTCELL_DIR=/run/hotcell/cell
 
+# ImageMagick's pixel cache limits. A decoded frame is `width x height x bytes per pixel` (8 for RGB(A) in
+# ImageMagick 6 Q16), held in heap up to MEMORY_LIMIT, otherwise written whole to a file on scratch up to DISK_LIMIT,
+# otherwise refused (`cache resources exhausted`, which the cell reports as `unreadable`). All three count
+# every frame of the process together. Without DISK_LIMIT one layered PSD fills the scratch every worker
+# shares. The variables reach ImageMagick in-process, through libvips' `magickload`, and in the `magick`
+# the cell spawns. docs/DEPLOYMENT.md "Size ImageMagick's pixel cache limits" derives the numbers; these
+# are for the worked example there (memory 2g, tmpfs 512m, concurrency 4, image operations' file_size 48MB):
+#
+#     MEMORY_LIMIT = (memory - tmpfs) / concurrency - worker footprint
+#                  = 384MiB - ~82MiB = 302MiB ceiling, rounded down to 256MiB
+#     DISK_LIMIT   = min(file_size, (scratch - reserve) / concurrency - staged files x file_size), never negative
+#                  = min(48MiB, (512MiB - 64MiB) / 4 - 2 x 48MiB) = 16MiB
+#     MAP_LIMIT    = DISK_LIMIT (it only decides whether the spill file is memory-mapped)
+#
+# Recompute when memory, the tmpfs size, concurrency, the reserve or file_size move.
+ENV MAGICK_MEMORY_LIMIT=256MiB \
+    MAGICK_DISK_LIMIT=16MiB \
+    MAGICK_MAP_LIMIT=16MiB
+
 WORKDIR /hotcell
 
 # For a reproducible dependency graph, commit a Gemfile.lock next to the Gemfile so a clean build resolves

--- a/hotcell-client/lib/hot_cell/install/Dockerfile.tt
+++ b/hotcell-client/lib/hot_cell/install/Dockerfile.tt
@@ -61,11 +61,19 @@ ENV HOME=/tmp \
 #
 #     MEMORY_LIMIT = (memory - tmpfs) / concurrency - worker footprint
 #                  = 384MiB - ~82MiB = 302MiB ceiling, rounded down to 256MiB
-#     DISK_LIMIT   = min(file_size, (scratch - reserve) / concurrency - staged files x file_size), never negative
-#                  = min(48MiB, (512MiB - 64MiB) / 4 - 2 x 48MiB) = 16MiB
+#                  (drop the tmpfs term on a disk-backed scratch; keep it under every reaching
+#                   operation's own `memory`, or the cache dies on RLIMIT_DATA instead of being refused)
+#     DISK_LIMIT   = (scratch - reserve) / concurrency - staged files x file_size, never negative
+#                  = (512MiB - 64MiB) / 4 - 2 x 48MiB = 16MiB
 #     MAP_LIMIT    = DISK_LIMIT (it only decides whether the spill file is memory-mapped)
 #
-# Recompute when memory, the tmpfs size, concurrency, the reserve or file_size move.
+# DISK_LIMIT is not clamped to file_size: file_size is RLIMIT_FSIZE and bounds each cache file, this
+# bounds their sum. It is a residual, not a judgement about images — MEMORY_LIMIT is what bounds a single
+# frame, since a cache that misses memory must fit the disk limit on its own.
+#
+# The arithmetic is per operation and this is one environment: work each operation that can reach
+# ImageMagick and set the smallest result. Recompute when memory, the tmpfs size, concurrency, the
+# reserve or file_size move.
 ENV MAGICK_MEMORY_LIMIT=256MiB \
     MAGICK_DISK_LIMIT=16MiB \
     MAGICK_MAP_LIMIT=16MiB

--- a/hotcell-client/test/install_test.rb
+++ b/hotcell-client/test/install_test.rb
@@ -83,6 +83,19 @@ class InstallTest < HotCellClientTest
     end
   end
 
+  # ImageMagick's default disk limit is unbounded, and one layered PSD is enough to fill the scratch every
+  # worker shares. The failure only appears in a running cell, so the scaffold's own text is what holds it.
+  def test_install_bounds_imagemagicks_spill_to_a_workers_share_of_scratch
+    Dir.mktmpdir do |root|
+      HotCell::Install.call(root, out: StringIO.new)
+      dockerfile = File.read(File.join(root, "hotcell", "Dockerfile"))
+
+      disk, map = %w[ DISK MAP ].map { |name| dockerfile[/^\s*MAGICK_#{name}_LIMIT=(\d+)MiB\s*\\?$/, 1] }
+      assert disk, "no MAGICK_DISK_LIMIT"
+      assert_operator Integer(map), :<=, Integer(disk)
+    end
+  end
+
   # `--pull` takes the newest base tag, but that tag itself can sit behind a Debian advisory until
   # docker-library/ruby rebuilds it, and the image scan gate blocks on a fixable High no rebuild of this
   # repository can clear. Applying the pending security patches during the build makes the gate's claim the


### PR DESCRIPTION
On 2026-09-01 one layered PSD filled BC5's 4G cell scratch on six hosts, and every image that arrived while it was full took a permanent `unreadable` verdict: 3,393 blobs convicted. That image's ImageMagick disk limit was `10GiB` against a 4G mount, so it never refused. Post-mortem: [card 10261975276](https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10261975276).

Two commits on the #51 merge. Supersedes #53, which GitHub closed when I pushed this branch to `master` by mistake; `master` is back at `67c51383`.

## What ImageMagick does with an image

ImageMagick cannot work on a JPEG or a PSD as it is. It first unpacks every frame into a *pixel cache*: a flat array of `width × height × bytes per pixel`. The bytes per pixel come from the build. Basecamp's cell image carries ImageMagick 6.9.12 Q16, which stores four 16-bit channels for every pixel, so 8 bytes, or 10 when the image has a black or palette-index channel (CMYK, palette). `convert -size 1000x1000 xc:red -debug cache info:` in that image reports the cache as `7.62939MiB`, which is 1,000,000 × 8. So a 4096 × 4096 RGB image is 128MiB before ImageMagick does anything to it, a layered PSD holds one cache per layer at the same time, and a transform holds the source and the result at once.

Where a cache goes is decided by three limits, read from the environment as ImageMagick loads ([resources](https://imagemagick.org/script/resources.php)). All three count every cache the process has open, added together:

1. `MAGICK_MEMORY_LIMIT`. A new cache goes on the heap while the caches already open plus this one fit under it.
2. When it does not fit, the whole cache goes to a file under `MAGICK_TMPDIR` instead, and counts against `MAGICK_DISK_LIMIT`. `MAGICK_MAP_LIMIT` decides whether that file is memory-mapped or read with plain I/O. Same file, same disk, so it is never set above the disk limit.
3. When it does not fit under the disk limit either, ImageMagick fails with `cache resources exhausted`. The cell reports that as `unreadable`.

A cache never straddles a limit: it goes to memory whole or to disk whole. So one frame is decodable only if it fits under the memory limit or under the disk limit on its own, and a multi-frame file only if all its frames fit under the two added together. ImageMagick's defaults are most of the host's RAM and an unbounded disk. `policy.xml` in the image is a ceiling the environment can lower and never raise; `identify -list resource` shows the result.

`MAGICK_AREA_LIMIT` is not set. The docs say an image over `area` is "cached to disk rather than memory", not refused, and a 100-pixel `MAGICK_AREA_LIMIT` on a 4000 × 4000 `xc:` confirms it: the image processes. An earlier revision of this PR set it and called it a refusal; that was wrong.

## Why the disk limit is the one that matters

Without it, step 2 has no ceiling. A layered PSD writes one cache file per layer until the tmpfs is full. The cell's `file_size` is `RLIMIT_FSIZE`, which bounds each file and cannot bound their sum. That is the 2026-09-01 failure.

## The arithmetic for the installed Dockerfile

The scaffold's `Dockerfile` installs no ImageMagick; the application adds it. So the three values it sets are for the worked example in `docs/DEPLOYMENT.md`, and the new section "Size ImageMagick's pixel cache limits" is how an application recomputes them. The inputs:

- Container `memory: 2g` and tmpfs `size=512m` (README accessory).
- `concurrency: 4` (`config.rb`).
- `file_size: 48MB` for `analyzers.image.magick` and `transformers.image.magick`, where "MB" is `1024²` as `config.rb` writes it.
- `transformers.image.magick` stages its input onto scratch, because mini_magick cannot take a descriptor, and writes its output there: two files per request, each up to `file_size`.

**Disk.** The 512MiB tmpfs is shared by four workers, and the disk limit counts only ImageMagick's cache files. Other things live on the same tmpfs: each request's staged input and output, and libvips' own temporary files for a large image. So hold a reserve back, split the rest four ways, take out the two staged files, and the remainder is what ImageMagick may spill. It must also stay at or under `file_size`, because `RLIMIT_FSIZE` would otherwise fire on a single cache file before ImageMagick's own check does.

```
available         = (scratch − reserve) ÷ concurrency − staged files × file_size
                  = (512MiB − 64MiB) ÷ 4 − 2 × 48MiB
                  = 112MiB − 96MiB
                  = 16MiB
MAGICK_DISK_LIMIT = min(file_size, available) = min(48MiB, 16MiB) = 16MiB
MAGICK_MAP_LIMIT  = MAGICK_DISK_LIMIT = 16MiB
```

Check: four workers at that peak at once are `4 × (48 + 48 + 16) = 448MiB`, and the 64MiB reserve is left for everything else. The reserve is an illustrative margin; the docs say to size it from measured non-cache use. `available` must come out at zero or more; a negative number tells ImageMagick the limit is huge.

**Memory.** The container's `memory` is a cgroup limit, and the tmpfs is charged to it byte for byte, so the processes get what the scratch cannot take. What a worker costs before any image: about 70MiB resident with libvips and mini_magick loaded, plus about 12MiB for the `convert` it spawns (`getrusage` in Basecamp's cell image).

```
for processes       = 2048MiB − 512MiB = 1536MiB
per worker          = 1536MiB ÷ 4 = 384MiB
ceiling             = 384MiB − 82MiB = 302MiB
MAGICK_MEMORY_LIMIT = 256MiB
```

256MiB is the round number under the ceiling. The 46MiB a worker it leaves is for the supervisor and for what the limit does not count: libvips' buffers, coder scratch, and algorithms ImageMagick documents as not honouring the limits. Check: four workers at the limit plus a full tmpfs are `4 × (256 + 82) + 512 = 1864MiB` against the 2048MiB cgroup. The cell's `memory` (`RLIMIT_DATA`, 1280MB for the transformer) is inherited by the `magick` child and sits well above this, so it never fires first.

**What that buys.** 256MiB ÷ 8 bytes is 33,554,432 pixels: 8192 × 4096 exactly, or 5792 × 5792. With an index channel, 26.8 million. That is the sum of every cache open at once, so a same-size transform decodes half that, and a thumbnail a little less than the whole. The 16MiB on disk adds nothing for a single frame, since a frame that misses memory has to fit on disk on its own; a multi-frame file may total 272MiB. Anything larger is `unreadable` with an empty scratch, instead of a full scratch and a dead cell.

## The other commit

**Forward the worker's `MAGICK_*` environment into `MiniMagick.cli_env`, per request.** `restricted_env` drops it with the rest of the worker's environment, so an image's `MAGICK_DISK_LIMIT` bounded ImageMagick only in-process, through libvips' `magickload`, and the `TMPDIR` #51 sets for the request never reached `magick` either. The `magick` behind `analyzers.image.magick` and `transformers.image.magick` ran under ImageMagick's defaults and spilled to the shared `/tmp`. `MagickOperation#initialize` now builds the hash after `super` has mapped `MAGICK_TMPDIR` from `TMPDIR`, carrying `MAGICK_*_LIMIT`, `TMPDIR` and `MAGICK_TMPDIR` as the OpenMP pair already was; the require-time set stays for the binary lookup. `magick_environment_test.rb` covers our hash, what mini_magick hands `magick` (`{}` and `Disk: unlimited` before), and that setting only `TMPDIR` before `.new` puts both directories in `cli_env`.

## Review

The arithmetic and its assumptions went through three rounds with Codex as an independent reviewer. Round 1: one H (no scratch reserve), five M (a 122MiB-vs-128MiB slip, the 302MiB ceiling stated as an OOM boundary, the missing `≤ file_size` clause, `policy.xml` `temporary-path` overriding `MAGICK_TMPDIR`, disk-backed page-cache accounting) and one L. All applied except the page-cache point, which is about the pre-existing "Where scratch lives" section. Round 2: one H (a negative `available` reads as huge), four M, two L, all applied. Round 3: "No H or M deltas. Every displayed number and subtotal checks out."

Measured earlier on BC5's production cell image with the incident's blob, single request, `--memory 2g`. As shipped: `killed: crashed (libgomp …)` after 5 s and 1.1 GB of `magick-*` orphans in the scratch root. With `MAGICK_DISK_LIMIT=768MiB MAGICK_MAP_LIMIT=768MiB` and an area limit since dropped: `unreadable: Vips::Error: magickload: libMagick error: cache resources exhausted` after 159 ms, scratch root empty. Those were bc3's numbers for its 4G scratch, not the scaffold's; bc3 and HEY recompute from the section above in their own PRs. Fizzy's cell keeps `magickload` blocked and never runs ImageMagick, so it gets none.

An upgrade leaves an installed `Dockerfile` alone, so an existing cell adds the `ENV` block by hand and rebuilds.

ref: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10270096028
