### PR TITLE
Stop passing create_additions to JSON.parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ gem but are what an operator runs against their own image.
 
 ## next / unreleased
 
+### HotCell::Core
+
+#### Fixed
+
+* json 3.0.0 support.
+
 ### HotCell::Server
 
 #### Fixed

--- a/examples/lib/battery.rb
+++ b/examples/lib/battery.rb
@@ -136,27 +136,40 @@ module Examples
         assert gone, "the grandchild (pid #{pid}) outlived its worker"
       end
 
-      # Fills every worker and every queue place with sleeps, then offers one more. The blockers' own
-      # outcomes are deliberately not asserted: the queued ones may run or may wait, and either way the
-      # cell is full when the last request arrives.
+      # Fills every worker and every queue place with sleeps, then offers one more. The offer waits until
+      # metrics count every place taken rather than for a fixed interval: on a slow runner a blocker can
+      # take longer than that to arrive, and the offer then takes its place and succeeds. The blockers'
+      # own outcomes are not asserted: the queued ones may run or may wait, and either way the cell is full
+      # when the last request arrives. They are reported when the cell never fills, so a blocker that
+      # failed says why.
       def overload
         places = @described.fetch(:concurrency) + @described.fetch(:queue_size)
         blockers = places.times.map do
           Thread.new do
             Sleep.perform_in_hotcell [], [], { seconds: 2 }
-          rescue StandardError
-            nil
+          rescue StandardError => error
+            error
           end
         end
 
         begin
-          sleep 0.5
+          unless within(5) { occupied == places }
+            failures = blockers.map(&:value).grep(StandardError).map(&:message)
+            raise Failed, "#{occupied} of #{places} places filled; blockers failed with #{failures.inspect}"
+          end
+
           expect_failure @cell.transient, /\Acapacity/ do
             Sleep.perform_in_hotcell [], [], { seconds: 2 }
           end
         ensure
           blockers.each(&:join)
         end
+      end
+
+      def occupied
+        response = @cell.metrics
+        assert response&.ok?, "the control socket did not answer metrics: #{response&.failure}"
+        response.result.fetch(:running) + response.result.fetch(:queued)
       end
 
       def still_serving

--- a/hotcell-core/lib/hot_cell/payload.rb
+++ b/hotcell-core/lib/hot_cell/payload.rb
@@ -22,27 +22,21 @@ module HotCell
         JSON.generate object
       end
 
-      # Keys are deep-symbolized here rather than in an operation, so an operation never has to know
-      # whether to reach for payload[:format] or payload["format"], and a nested hash can be splatted
-      # straight into a library's keyword arguments. Only keys: a Symbol value would not survive the
-      # round trip, which the JSON-native rule already forbids.
+      # Keys are symbolized so operations read payload[:format] and can splat a nested hash into keyword
+      # arguments. Values are not: a Symbol would not survive the round trip, which the JSON-native rule
+      # already forbids.
       #
-      # JSON.parse only. Never JSON.load, and never create_additions, both of which instantiate
-      # arbitrary classes named by a json_class key in the document.
+      # One rescue for the whole JSON layer. Naming what JSON.parse raises has been wrong twice: a report
+      # that was not an object raised TypeError past a rescue for JSON::ParserError, and a key holding
+      # invalid UTF-8 raised EncodingError past both. The supervisor parses worker reports inside its
+      # deadline loop with nothing above it rescuing, so each miss denies service to every request in the
+      # cell.
       #
-      # Every way this can fail becomes one named failure, and the catch-all is the point rather than
-      # laziness. Callers used to name what JSON.parse raises, and naming it has now been wrong twice: a
-      # report that was not an object raised TypeError past a rescue for JSON::ParserError, and a key
-      # holding bytes that are not valid UTF-8 raises EncodingError past both. The supervisor reads worker
-      # reports through here inside the loop that enforces every request's deadline, and nothing above it
-      # rescues anything, so each miss is a one-line denial of service against every request in the cell.
-      #
-      # The body is a single JSON.parse call, so this is scoped to "the JSON layer failed" and cannot
-      # swallow a bug in our own code. NoMemoryError is deliberately not caught: it is not a StandardError,
-      # and a document large enough to raise it is the worker's own memory verdict rather than a bad line.
+      # The body is one JSON.parse call, so the rescue cannot hide a bug of our own. NoMemoryError is not
+      # a StandardError and stays uncaught: a document that large is the worker's memory verdict, not a
+      # bad line.
       def parse(json)
-        JSON.parse json, symbolize_names: true, max_nesting: MAX_NESTING, allow_nan: false,
-                         create_additions: false
+        JSON.parse json, symbolize_names: true, max_nesting: MAX_NESTING, allow_nan: false
       rescue StandardError => error
         raise MessageError, "#{error.class}: #{Failure.sanitize(error.message)}"
       end


### PR DESCRIPTION
Two commits.

**Stop passing `create_additions` to `JSON.parse`.** `Gemfile.lock` is gitignored, so CI resolves gems fresh. [json 3.0.0](https://github.com/ruby/json/blob/v3.0.0/CHANGES.md), released 2026-09-07, removed the `create_additions` option and raises `ArgumentError` on any unknown keyword. `HotCell::Payload.parse` passed `create_additions: false`, so every request and response failed to parse and every cell-backed job went red, on `master` as well as on #52. Drop the keyword: `JSON.parse` never enabled `create_additions` on json 2.x, and `test_a_json_class_key_instantiates_nothing` still covers the guarantee the option was spelling out. The suites pass under json 3.0.0 and 2.21.2. The `parse` comment is rewritten and the changelog entry is under `HotCell::Core / Fixed`. `VERSION` is already `0.3.2.dev`, so no bump.

**Wait for the cell to fill before offering the overload request.** The `examples/devcell` battery's overload check slept 0.5s after starting its blockers and then offered one more request, expecting `capacity`. On one `hotcell (ruby 4.0)` run only two of the four blockers had reached the cell by then, so the offer took a queue place and succeeded. The offer now polls the control socket's metrics until `running + queued` equals every place, bounded at 5s, and reports the blockers' own errors if the cell never fills. `rake test:devcell` 10 of 10 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
