### PR TITLE
Document ImageMagick's resource limits in a cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ gem but are what an operator runs against their own image.
 #### Fixed
 
 * Every operation sets `MAGICK_TMPDIR` to the request's `TMPDIR`, so ImageMagick's pixel cache — from the `magick` the magick operations run and from the `magickload` libvips delegates to — is removed with the request, however it ends.
+* `MagickOperation` forwards the worker's `MAGICK_*_LIMIT`, `TMPDIR` and `MAGICK_TMPDIR` to the `magick` it spawns, read per request. `MiniMagick.restricted_env` had dropped them along with the rest of the environment, so an image's `MAGICK_DISK_LIMIT` bounded ImageMagick inside libvips and not the `magick` behind `analyzers.image.magick` and `transformers.image.magick`, which ran under ImageMagick's defaults — the host's RAM and an unbounded disk — and the request's `TMPDIR` above never reached it.
 
 #### Improved
 

--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ removed too early turns that processing off without an error.
 
 [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) covers all of this in detail: every container flag, how to
 size the numbers, the shared group, bringing your own container, and where scratch lives.
+[docs/IMAGEMAGICK.md](docs/IMAGEMAGICK.md) covers ImageMagick's own resource limits, which an image that
+installs it must size from the same numbers.
 
 ### Using custom operations
 

--- a/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
+++ b/activestorage-hotcell-server/lib/active_storage/hot_cell/server/magick_operation.rb
@@ -8,29 +8,6 @@ require "active_storage/hot_cell/server/operation"
 # toolchains' loads in the same place is what makes a single cell carrying both legible.
 require "image_processing/mini_magick"
 
-# Invariant 9: a tool sees only the environment its operation wrote for it. `Operation#run_tool` holds it
-# with `unsetenv_others: true`, and these operations do not use it — mini_magick spawns `magick` itself.
-# `MiniMagick.restricted_env` is `false` by default, and with it false mini_magick calls
-# `Open3.popen3({}, *command, unsetenv_others: false)`, so `magick` inherited this worker's whole
-# environment. `bin/conformance` did not catch it, because its environment check drives an operation that
-# goes through `run_tool`.
-#
-# `cli_env` names the locale for the reason `tool_environment` does: a tool's output must not shift under
-# it. mini_magick passes `HOME`, `PATH` and `LANG` and does not pass `LC_ALL`, so both go here.
-#
-# Set at require time rather than in `before_worker_boot`, so that the binary lookup this require performs
-# is covered too. Note what this is: mini_magick filters the environment it was given, where `run_tool`
-# writes a fresh one. Driving `magick` directly would make it ours, and that is the separate enhancement
-# this class already names.
-#
-# The OpenMP variables come from the cell's environment rather than being named here: the number belongs
-# to the image, which is configured to match the container's CPU quota. Without them the restriction would
-# hand `magick` the pool the image's bound was meant to take away. `run_tool` carries the same pair.
-MiniMagick.restricted_env = true
-MiniMagick.cli_env = { "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
-                       "OMP_NUM_THREADS" => ENV["OMP_NUM_THREADS"],
-                       "OMP_THREAD_LIMIT" => ENV["OMP_THREAD_LIMIT"] }.compact
-
 module ActiveStorage
   module HotCell
     module Server
@@ -46,6 +23,40 @@ module ActiveStorage
       # operations never had.
       class MagickOperation < Operation
         abstract_operation
+
+        # Invariant 9: a tool sees only the environment its operation wrote for it. `Operation#run_tool` holds
+        # it with `unsetenv_others: true`, and these operations do not use it — mini_magick spawns `magick`
+        # itself. `MiniMagick.restricted_env` is `false` by default, and with it false mini_magick calls
+        # `Open3.popen3({}, *command, unsetenv_others: false)`, so `magick` inherited this worker's whole
+        # environment. `bin/conformance` did not catch it, because its environment check drives an operation
+        # that goes through `run_tool`. Note what this is: mini_magick filters the environment it was given,
+        # where `run_tool` writes a fresh one. Driving `magick` directly would make it ours, and that is the
+        # separate enhancement this class already names.
+        #
+        # The locale is named for the reason `tool_environment` names it: a tool's output must not shift under
+        # it. mini_magick passes `HOME`, `PATH` and `LANG` and does not pass `LC_ALL`, so both go here.
+        #
+        # Everything else comes from the worker's environment rather than being named here. The OpenMP pair
+        # belongs to the image, which is configured to match the container's CPU quota. ImageMagick's own
+        # resource ceilings, `MAGICK_DISK_LIMIT` and its siblings, are read from its environment as it loads
+        # and the image sets them to a worker's share of the scratch; without them `magick` runs under
+        # ImageMagick's defaults, the host's RAM and an unbounded disk. `TMPDIR` and `MAGICK_TMPDIR` are where
+        # it spills that cache: the worker sets the first to the request's home after the fork and
+        # `Operation#initialize` maps the second from it — which is why this is read per request, after
+        # `super`, and not once at require: a hash built then hands `magick` the supervisor's `/tmp`, which is
+        # swept only at the next boot.
+        def self.cli_env
+          { "LANG" => "C.UTF-8", "LC_ALL" => "C.UTF-8",
+            "OMP_NUM_THREADS" => ENV["OMP_NUM_THREADS"], "OMP_THREAD_LIMIT" => ENV["OMP_THREAD_LIMIT"],
+            "TMPDIR" => ENV["TMPDIR"], "MAGICK_TMPDIR" => ENV["MAGICK_TMPDIR"] }
+            .merge(ENV.select { |name, _| name.match?(/\AMAGICK_\w+_LIMIT\z/) })
+            .compact
+        end
+
+        def initialize
+          super
+          MiniMagick.cli_env = self.class.cli_env
+        end
 
         # MiniMagick::Error is how mini_magick reports a `magick` that exited non-zero — the common shape of an
         # input it cannot decode. MiniMagick::Invalid is an input `identify` rejects outright.
@@ -69,3 +80,7 @@ module ActiveStorage
     end
   end
 end
+
+# Also at require time, so that the binary lookup the require above performs is covered too.
+MiniMagick.restricted_env = true
+MiniMagick.cli_env = ActiveStorage::HotCell::Server::MagickOperation.cli_env

--- a/activestorage-hotcell-server/test/magick_environment_test.rb
+++ b/activestorage-hotcell-server/test/magick_environment_test.rb
@@ -17,6 +17,9 @@ require "etc"
 # does not read it decodes normally. The cell is forked from this process, so the variable reaches the
 # worker.
 class MagickEnvironmentTest < ActiveStorageHotCellTest
+  UNSET = %w[ OMP_NUM_THREADS OMP_THREAD_LIMIT MAGICK_DISK_LIMIT MAGICK_MAP_LIMIT TMPDIR MAGICK_TMPDIR ]
+    .to_h { |name| [ name, nil ] }
+
   def test_magick_does_not_inherit_the_workers_environment
     with_refusing_policy_in_the_environment do
       Cell.boot do |cell|
@@ -46,6 +49,37 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
 
     assert_equal bound, magick_cli_env_under(bound)
     assert_empty magick_cli_env_under({}), "the cell invented a bound of its own"
+  end
+
+  # ImageMagick reads its resource ceilings out of its own environment, and the image is where they are set,
+  # so the restriction above would otherwise hand `magick` ImageMagick's defaults: the host's RAM and an
+  # unbounded disk.
+  def test_the_cli_env_carries_the_images_imagemagick_resource_limits
+    limits = { "MAGICK_DISK_LIMIT" => "768MiB", "MAGICK_MAP_LIMIT" => "768MiB" }
+
+    assert_equal limits, magick_cli_env_under(limits, *limits.keys)
+    assert_empty magick_cli_env_under({}, *limits.keys), "the cell invented a limit of its own"
+  end
+
+  def test_mini_magick_hands_the_resource_limits_to_magick
+    skip "ImageMagick is not installed" unless magick_installed?
+
+    assert_equal "768MiB", magick_resource_through_mini_magick("Disk", "MAGICK_DISK_LIMIT" => "768MiB")
+  end
+
+  # The worker sets TMPDIR to the request's home after the fork and `Operation#initialize` maps MAGICK_TMPDIR
+  # from it, so a hash built when the operation was required would send ImageMagick's spill to the
+  # supervisor's /tmp, where nothing sweeps it.
+  def test_the_cli_env_follows_the_requests_tmpdir
+    where = { "TMPDIR" => "/tmp/request-home", "MAGICK_TMPDIR" => "/tmp/request-home" }
+
+    assert_equal where, JSON.parse(in_a_child({}, <<~RUBY))
+      require "json"
+      require "active_storage/hot_cell/server/analyzers/image/magick"
+      ENV["TMPDIR"] = "/tmp/request-home"
+      ActiveStorage::HotCell::Server::Analyzers::Image::Magick.new
+      puts JSON.dump(MiniMagick.cli_env.slice("TMPDIR", "MAGICK_TMPDIR"))
+    RUBY
   end
 
   # mini_magick, rather than our hash: it is unbounded in the gemspec, and a version that stopped merging
@@ -85,11 +119,13 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
   end
 
   private
-    def magick_cli_env_under(environment)
+    def magick_cli_env_under(environment, *names)
+      names = %w[ OMP_NUM_THREADS OMP_THREAD_LIMIT ] if names.empty?
+
       JSON.parse in_a_child(environment, <<~RUBY)
         require "json"
         require "active_storage/hot_cell/server/magick_operation"
-        puts JSON.dump(MiniMagick.cli_env.slice("OMP_NUM_THREADS", "OMP_THREAD_LIMIT"))
+        puts JSON.dump(MiniMagick.cli_env.slice(*#{names.inspect}))
       RUBY
     end
 
@@ -97,18 +133,20 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
     # merges into that child is what the assertion is about. Nothing here rescues, so a child that cannot
     # run fails the test rather than reading as a bound of zero.
     def magick_threads_through_mini_magick(environment)
-      output = in_a_child(environment, <<~'RUBY')
-        require "active_storage/hot_cell/server/magick_operation"
-        print MiniMagick.convert { |command| command.list "resource" }[/Thread: (\d+)/, 1]
-      RUBY
+      Integer(magick_resource_through_mini_magick("Thread", environment))
+    end
 
-      Integer(output)
+    def magick_resource_through_mini_magick(resource, environment)
+      in_a_child(environment, <<~RUBY)
+        require "active_storage/hot_cell/server/magick_operation"
+        print MiniMagick.convert { |command| command.list "resource" }[/#{resource}: (\\S+)/, 1]
+      RUBY
     end
 
     # The operation reads the variables at require time, so each case needs its own process. A developer's
-    # own shell may hold either, so the child starts from neither and takes only what the case gives it.
+    # own shell may hold any of them, so the child starts from none and takes only what the case gives it.
     def in_a_child(environment, script)
-      environment = { "OMP_NUM_THREADS" => nil, "OMP_THREAD_LIMIT" => nil, "MAGICK_TMPDIR" => nil }.merge(environment)
+      environment = UNSET.merge(environment)
       lib = File.expand_path("../lib", __dir__)
 
       IO.popen([ environment, RbConfig.ruby, "-I", lib, "-r", "bundler/setup", "-e", script ], &:read)

--- a/activestorage-hotcell-server/test/magick_environment_test.rb
+++ b/activestorage-hotcell-server/test/magick_environment_test.rb
@@ -17,8 +17,8 @@ require "etc"
 # does not read it decodes normally. The cell is forked from this process, so the variable reaches the
 # worker.
 class MagickEnvironmentTest < ActiveStorageHotCellTest
-  UNSET = %w[ OMP_NUM_THREADS OMP_THREAD_LIMIT MAGICK_DISK_LIMIT MAGICK_MAP_LIMIT TMPDIR MAGICK_TMPDIR ]
-    .to_h { |name| [ name, nil ] }
+  UNSET = %w[ OMP_NUM_THREADS OMP_THREAD_LIMIT MAGICK_MEMORY_LIMIT MAGICK_MAP_LIMIT MAGICK_DISK_LIMIT
+              MAGICK_AREA_LIMIT MAGICK_THREAD_LIMIT TMPDIR MAGICK_TMPDIR ].to_h { |name| [ name, nil ] }
 
   def test_magick_does_not_inherit_the_workers_environment
     with_refusing_policy_in_the_environment do
@@ -116,6 +116,27 @@ class MagickEnvironmentTest < ActiveStorageHotCellTest
     RUBY
 
     assert_equal [ nil, "/scratch/home-for-this-request" ], JSON.parse(output)
+  end
+
+  # The premise of the mapping above, proved on the child rather than on our hash: `magick` given a memory
+  # limit its cache cannot fit writes that cache under `MAGICK_TMPDIR`, and `MAGICK_TMPDIR` is the request's
+  # `TMPDIR` at the time the operation was instantiated.
+  def test_magick_spills_its_cache_into_the_requests_tmpdir
+    skip "ImageMagick is not installed" unless magick_installed?
+
+    Dir.mktmpdir do |home|
+      cache_log = in_a_child({}, <<~RUBY)
+        require "active_storage/hot_cell/server/analyzers/image/magick"
+        ENV["TMPDIR"] = #{home.inspect}
+        ENV["MAGICK_MEMORY_LIMIT"] = ENV["MAGICK_MAP_LIMIT"] = "1MiB"
+        ActiveStorage::HotCell::Server::Analyzers::Image::Magick.new
+        convert = MiniMagick.convert.debug("cache").size("500x500")
+        convert << "xc:red" << "info:"
+        convert.call(errors: false) { |_stdout, stderr, _status| print stderr }
+      RUBY
+
+      assert_match %r{\(#{Regexp.escape(home)}/magick-\S+, disk}, cache_log
+    end
   end
 
   private

--- a/activestorage-hotcell-server/test/magick_environment_test.rb
+++ b/activestorage-hotcell-server/test/magick_environment_test.rb
@@ -17,8 +17,8 @@ require "etc"
 # does not read it decodes normally. The cell is forked from this process, so the variable reaches the
 # worker.
 class MagickEnvironmentTest < ActiveStorageHotCellTest
-  UNSET = %w[ OMP_NUM_THREADS OMP_THREAD_LIMIT MAGICK_MEMORY_LIMIT MAGICK_MAP_LIMIT MAGICK_DISK_LIMIT
-              MAGICK_AREA_LIMIT MAGICK_THREAD_LIMIT TMPDIR MAGICK_TMPDIR ].to_h { |name| [ name, nil ] }
+  UNSET = (%w[ OMP_NUM_THREADS OMP_THREAD_LIMIT MAGICK_DISK_LIMIT MAGICK_MAP_LIMIT TMPDIR MAGICK_TMPDIR ] +
+           ENV.keys.grep(/\AMAGICK_\w+_LIMIT\z/)).uniq.to_h { |name| [ name, nil ] }
 
   def test_magick_does_not_inherit_the_workers_environment
     with_refusing_policy_in_the_environment do

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -514,9 +514,10 @@ Nothing checks these for you.
 - `file_size × concurrency` must be no more than the scratch. Above it, concurrent workers fill the
   scratch and requests fail with `ENOSPC` instead of with a limit verdict. On the default accessory the
   scratch is the tmpfs, and its `size=` is the number to fit.
-- `MAGICK_DISK_LIMIT × concurrency` must be no more than the scratch. Above it, concurrent ImageMagick
-  processes fill the scratch before any of them refuses a frame, and `file_size` cannot prevent that,
-  because it bounds each cache file and not their sum. See [docs/IMAGEMAGICK.md](IMAGEMAGICK.md).
+- `concurrency × (MAGICK_DISK_LIMIT + everything else one worker writes on scratch)` must be no more
+  than the scratch. Above it, concurrent ImageMagick processes fill the scratch before any of them
+  refuses a frame, and `file_size` cannot prevent that, because it bounds each cache file and not their
+  sum. See [docs/IMAGEMAGICK.md](IMAGEMAGICK.md).
 
 Three things are fixed and cannot be configured: the one-second grace between the signal to a worker and
 the kill of its process group, the absence of an `RLIMIT_CPU`, and the socket file mode.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -211,7 +211,8 @@ serves requests exactly as before.
 
 ### General
 
-Environment variables. The image sets all of them, so set one only to override it.
+Environment variables. The image sets all of them unless the table says otherwise, so set one only to
+override it.
 
 | Variable | Default | What it does |
 | --- | --- | --- |
@@ -223,6 +224,7 @@ Environment variables. The image sets all of them, so set one only to override i
 | `HOME` | `/tmp` | Bundler needs one, and the cell's user has no home directory. A worker replaces it with a directory made for the request and removed with it. |
 | `OMP_NUM_THREADS` | `2` | The OpenMP pool size libvips and ImageMagick use. Match it to `cpus`. See "Bound the OpenMP thread pools". |
 | `OMP_THREAD_LIMIT` | `8` | The ceiling on that pool, including a library that raises the count itself. |
+| `MAGICK_MEMORY_LIMIT`, `MAGICK_MAP_LIMIT`, `MAGICK_DISK_LIMIT` | unset | ImageMagick's pixel cache limits. The scaffold installs no ImageMagick; an image that does sets these from the container's `memory`, the scratch and `concurrency`. See [docs/IMAGEMAGICK.md](IMAGEMAGICK.md). |
 
 ### Bound the OpenMP thread pools
 
@@ -502,16 +504,19 @@ matching, storing or rendering are all places these values raise.
 
 ## Making the numbers agree
 
-Nothing checks these three for you.
+Nothing checks these for you.
 
 - The client's `timeout` must be more than the cell's `answer_within`, which is
   `queue_wait + deadline + 1`. Below it, a saturated cell reaches the caller as a transport failure
   instead of as `capacity` or `killed`. The client warns at boot, and `describe` reports the number.
-- The cell's `memory` must stay below the container's `memory`. At equal values the cgroup fires first,
-  and a cgroup kill is a `SIGKILL` with no diagnostic.
-- `file_size × concurrency` must fit scratch. Above it, concurrent workers fill it and requests fail
-  with `ENOSPC` instead of with a limit verdict. On the default accessory scratch is the tmpfs, and its
-  `size=` is the number to fit.
+- The cell's `memory` must be less than the container's `memory`. At equal values the cgroup fires
+  first, and a cgroup kill is a `SIGKILL` with no diagnostic.
+- `file_size × concurrency` must be no more than the scratch. Above it, concurrent workers fill the
+  scratch and requests fail with `ENOSPC` instead of with a limit verdict. On the default accessory the
+  scratch is the tmpfs, and its `size=` is the number to fit.
+- `MAGICK_DISK_LIMIT × concurrency` must be no more than the scratch. Above it, concurrent ImageMagick
+  processes fill the scratch before any of them refuses a frame, and `file_size` cannot prevent that,
+  because it bounds each cache file and not their sum. See [docs/IMAGEMAGICK.md](IMAGEMAGICK.md).
 
 Three things are fixed and cannot be configured: the one-second grace between the signal to a worker and
 the kill of its process group, the absence of an `RLIMIT_CPU`, and the socket file mode.

--- a/docs/IMAGEMAGICK.md
+++ b/docs/IMAGEMAGICK.md
@@ -34,17 +34,22 @@ array, and the limits decide where each cache lives. ImageMagick's
 | `MAGICK_THREAD_LIMIT` | threads | The OpenMP team ImageMagick asks for. |
 | `MAGICK_TMPDIR` | path | Where the cache files go. Read before `TMPDIR`. |
 
-Bytes per pixel come from the build: 8 on ImageMagick 6 Q16 (four 16-bit channels), 10 with an index or
-black channel. A 4096 × 4096 image is 128MiB before anything is done to it, a layered PSD holds one cache
+Bytes per pixel come from the build: 8 on ImageMagick 6 Q16 without HDRI, which is Ubuntu's
+`imagemagick-6.q16` (four 16-bit channels), 10 with an index or black channel; an HDRI build stores
+floats and doubles both. A 4096 × 4096 image is 128MiB before anything is done to it, a layered PSD holds one cache
 per layer at once, and a transform holds source and result at once.
 
 The three byte limits are a chain: heap, then mapped file, then plain file, and a cache takes one tier
 whole. Both file tiers count against `disk`. So a single frame is readable only if it fits `memory` or
-`disk` on its own, and a multi-frame file only if all its frames fit the two added together.
+`disk` on its own. A multi-frame file needs every frame placed in turn, each in the first tier with room
+left, so its frames can total at most `memory` plus `disk`, and less when they pack badly: a frame that
+misses the heap's remainder must fit the disk's remainder on its own.
 
-Each limit is the lowest of three sources: the build's default (most of the host's RAM, unbounded disk),
-`policy.xml`, which is a ceiling the environment can lower and never raise, and the environment, read
-once when the process starts. Limits are per process. `identify -list resource` prints the result.
+Each limit has three sources. The build's default (most of the host's RAM, unbounded disk) is replaced
+by the environment, upward or downward; `policy.xml` is a ceiling on both, which the environment can
+lower and never raise. They are read once: when the `magick` process starts, or at ImageMagick's first
+use inside a process that loaded the library. Limits are per process. `identify -list resource` prints
+the result.
 
 ### How they interact in a cell
 
@@ -102,7 +107,8 @@ separately and set the image to the smallest result.
 
     scratch ÷ concurrency − what else the operation writes on scratch
 
-Scratch is the tmpfs `size=` or the host filesystem's size; a named volume has no size to divide. The
+Scratch is the tmpfs `size=` or the host filesystem's usable size as `df` reports it, which on an ext4
+made with default options is 5% under the nominal size; a named volume has no size to divide. The
 subtraction is the operation's own files: its output, and its input if it stages one. The shipped image
 operations read their input through the descriptor and stage nothing; a transformer writes its output on
 scratch before copying it out. The result must be zero or more. Below zero, enlarge the scratch or lower
@@ -152,9 +158,10 @@ can set neither on a bind mount. [docs/DEPLOYMENT.md](DEPLOYMENT.md#a-host-mount
 
 | Input | Value | From |
 | --- | --- | --- |
-| scratch | 4096MiB | the loopback filesystem |
+| scratch | 4096MiB | the loopback filesystem's nominal size; the usable size is what `df` shows |
 | container `memory` | 2048MiB | `memory: 2g`, no tmpfs term |
 | `concurrency` | 4 | `config.rb`, twice `cpus` |
+| cell ceiling | `memory: 1536MB`, `file_size: 768MB` | `config.rb`; an operation's own limits are clamped to these |
 | `transformers.image.vips` | `memory: 1280MB`, `file_size: 768MB` | `file_size` raised in the application's operations file |
 | `analyzers.image.vips` | `memory: 1024MB`, `file_size: 48MB` | gem defaults |
 | `analyzers.image.magick` | `memory: 1024MB`, `file_size: 48MB` | gem defaults |
@@ -172,8 +179,9 @@ peak of 256MiB per worker:
     MAGICK_MAP_LIMIT  = 768MiB
 
 It equals the transformer's `file_size` because that was sized by the same arithmetic, and the
-application's test holds it. Four workers spilling 768MiB and writing 256MiB beside it fill the 4G
-exactly. On the analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill first.
+application's test holds it, and the cell ceiling allows it. Four workers spilling 768MiB and writing
+256MiB beside it fill the nominal 4G exactly, so the usable size is the number to check with `df`. On the
+analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill first.
 
 **Memory.**
 
@@ -201,7 +209,7 @@ and `disk` at 768MiB in `policy.xml`.
 | --- | --- | --- |
 | 384MiB heap | 50.3 million | 8192 × 6144 |
 | 768MiB disk | 100.7 million | 16384 × 6144 |
-| both, multi-frame | 151 million | a 20-layer PSD at 2740 × 2740 |
+| both, multi-frame | up to 151 million | a 19-layer PSD at 2740 × 2740: 6 layers on the heap, 13 on disk |
 
 A same-size transform holds source and result, so it decodes half a tier. A larger file is `unreadable`
 on its first request, and the scratch is empty afterwards. The limits the image had inherited from the

--- a/docs/IMAGEMAGICK.md
+++ b/docs/IMAGEMAGICK.md
@@ -180,10 +180,10 @@ peak of 256MiB per worker:
 
 It equals the transformer's `file_size` because that was sized by the same arithmetic, the
 application's test holds it, and the cell ceiling allows it. Four workers spilling 768MiB and writing
-256MiB beside it fill 4096MiB exactly, so the arithmetic assumes the whole 4G is usable: a filesystem made
-with `mkfs.ext4 -m 0`, or an image larger than 4G. On a 4G ext4 with the default 5% root reserve, `df`
-shows about 3891MiB usable and the same arithmetic gives 716MiB. Check `df` on a cell host before taking
-the number. On the analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill
+256MiB beside it fill 4096MiB exactly, so the arithmetic assumes `df --output=avail` on the empty mount
+reports at least 4096MiB, which a 4G image cannot: ext4's metadata takes some of it, and the default 5%
+root reserve takes more, leaving under 3891MiB, for which the same arithmetic gives 716MiB. Check `df` on
+a cell host before taking the number. On the analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill
 first.
 
 **Memory.**

--- a/docs/IMAGEMAGICK.md
+++ b/docs/IMAGEMAGICK.md
@@ -1,0 +1,236 @@
+# ImageMagick's resource limits in a cell
+
+ImageMagick bounds itself through the `MAGICK_*_LIMIT` environment variables and a `policy.xml`. The
+scaffold's `Dockerfile` installs no ImageMagick and sets none of them; an image that installs ImageMagick
+must set them. Part one describes the variables and how they interact with a cell. Part two is how to
+set them.
+
+[docs/DEPLOYMENT.md](DEPLOYMENT.md) covers the container flags and cell settings that part two starts
+from: `memory`, `concurrency`, `file_size`, and "Where scratch lives".
+
+- [Part one: what the variables do](#part-one-what-the-variables-do)
+  * [The variables](#the-variables)
+  * [How they interact in a cell](#how-they-interact-in-a-cell)
+- [Part two: how to set them](#part-two-how-to-set-them)
+  * [The formulas](#the-formulas)
+  * [A worked example](#a-worked-example)
+  * [Checking a built image](#checking-a-built-image)
+  * [When to recompute](#when-to-recompute)
+
+## Part one: what the variables do
+
+### The variables
+
+ImageMagick decodes every frame into a *pixel cache*, an uncompressed `width × height × bytes per pixel`
+array, and the limits decide where each cache lives. ImageMagick's
+[resources page](https://imagemagick.org/script/resources.php) is the reference; this table is the summary.
+
+| Variable | Unit | Bounds |
+| --- | --- | --- |
+| `MAGICK_MEMORY_LIMIT` | bytes | Caches on the heap, all frames together. |
+| `MAGICK_MAP_LIMIT` | bytes | Caches that missed the heap and are memory-mapped files. |
+| `MAGICK_DISK_LIMIT` | bytes | Cache files on disk, mapped or not, all frames together. Past it the operation fails with `cache resources exhausted`. |
+| `MAGICK_AREA_LIMIT` | pixels | The largest single frame allowed on the heap. Over it, the frame goes to a file even when the heap would hold it. It never refuses a frame. |
+| `MAGICK_THREAD_LIMIT` | threads | The OpenMP team ImageMagick asks for. |
+| `MAGICK_TMPDIR` | path | Where the cache files go. Read before `TMPDIR`. |
+
+Bytes per pixel come from the build: 8 on ImageMagick 6 Q16 (four 16-bit channels), 10 with an index or
+black channel. A 4096 × 4096 image is 128MiB before anything is done to it, a layered PSD holds one cache
+per layer at once, and a transform holds source and result at once.
+
+The three byte limits are a chain: heap, then mapped file, then plain file, and a cache takes one tier
+whole. Both file tiers count against `disk`. So a single frame is readable only if it fits `memory` or
+`disk` on its own, and a multi-frame file only if all its frames fit the two added together.
+
+Each limit is the lowest of three sources: the build's default (most of the host's RAM, unbounded disk),
+`policy.xml`, which is a ceiling the environment can lower and never raise, and the environment, read
+once when the process starts. Limits are per process. `identify -list resource` prints the result.
+
+### How they interact in a cell
+
+**The environment reaches both ImageMagicks.** ImageMagick runs in a cell two ways. In-process, when
+libvips delegates PSD, BMP and ICO to `magickload`; the library reads the worker's environment. As a
+child, when mini_magick spawns `identify` or `magick` for `analyzers.image.magick` and
+`transformers.image.magick`. mini_magick runs with `restricted_env`, which passes the child only `HOME`,
+`PATH`, `LANG` and `MiniMagick.cli_env`, so `MagickOperation` rebuilds `cli_env` for every request from
+the worker's `MAGICK_*_LIMIT`, `TMPDIR` and `MAGICK_TMPDIR`.
+
+**`MAGICK_TMPDIR` is the gem's.** `Operation#initialize` maps it from the request's `TMPDIR`, so in-process
+cache files land in the request's directory and are removed with it. Do not set it in the image, and do
+not set a `temporary-path` policy, which overrides it.
+
+**Every limit divides by `concurrency`.** The limits are per process, and the cell runs `concurrency`
+processes against one `/tmp` and one cgroup.
+
+**`file_size` cannot do the disk limit's job.** `file_size` is `RLIMIT_FSIZE`, a limit on each file. A
+layered PSD writes one cache file per layer, and twenty 40MiB caches total 800MiB with no file near a
+48MiB `file_size`. Only `MAGICK_DISK_LIMIT` bounds the sum. Where the two meet, the smaller fires
+first, as an `fsize` kill or as `cache resources exhausted`; both are permanent verdicts on the file.
+
+**A disk limit larger than the scratch is not a limit.** The scratch fills first. A full scratch fails
+every request on the cell that needs scratch, and a write that fails inside libvips is a `Vips::Error`,
+which the gem declares `unreadable`: permanent, and recorded against a customer's file. On 2026-09-01 one
+PSD under a `10GiB` disk limit filled a 4G scratch on six hosts and convicted 3,393 blobs. Under a
+disk limit sized to a worker's share, the same file is `unreadable` on its own first request, in
+milliseconds, with the scratch empty afterwards.
+
+**For `magickload`, the cache files are the spill.** libvips writes a decode above `VIPS_DISC_THRESHOLD`
+to `TMPDIR`; when the decode is ImageMagick's, its cache files stand in for that temporary rather than
+adding to it. So the disk limit and the transformer's `file_size` describe the same bytes.
+
+**A heap cache is charged to `RLIMIT_DATA` and to the cgroup.** It is private anonymous memory, so the
+operation's `memory` counts it and so does the container's. `MAGICK_MEMORY_LIMIT` plus the worker's own
+footprint must sit under a worker's share of the cgroup and under the `memory` of every operation that
+can reach ImageMagick. Above either, the process dies (`killed`, or libgomp's `exit(1)` on a thread it
+cannot create) instead of refusing the frame, and a death is transient: the request is retried against
+a limit that fails it again.
+
+**`MAGICK_AREA_LIMIT` adds nothing.** It moves the heap-or-file line in pixels; `memory` already draws it
+in bytes. Set below `memory`, it sends frames to scratch the heap could have held.
+
+**`MAGICK_THREAD_LIMIT` raises the OpenMP count itself**, and `OMP_THREAD_LIMIT` caps it. See
+[Bound the OpenMP thread pools](DEPLOYMENT.md#bound-the-openmp-thread-pools).
+
+## Part two: how to set them
+
+### The formulas
+
+Every "MiB" is `1024²` bytes, as `config.rb` writes it. Work each operation that can reach ImageMagick
+separately and set the image to the smallest result.
+
+**`MAGICK_DISK_LIMIT`**
+
+    scratch ÷ concurrency − what else the operation writes on scratch
+
+Scratch is the tmpfs `size=` or the host filesystem's size; a named volume has no size to divide. The
+subtraction is the operation's own files: its output, and its input if it stages one. The shipped image
+operations read their input through the descriptor and stage nothing; a transformer writes its output on
+scratch before copying it out. The result must be zero or more. Below zero, enlarge the scratch or lower
+`file_size` or `concurrency`; ImageMagick reads a negative value as a huge one.
+
+**`MAGICK_MAP_LIMIT`** = `MAGICK_DISK_LIMIT`. The mapped caches are the same files on the same scratch.
+
+**`MAGICK_MEMORY_LIMIT`**
+
+    (memory − tmpfs) ÷ concurrency − a worker's own footprint, rounded down
+
+On a disk-backed scratch there is no tmpfs term. The footprint is the worker's resident size with the
+gems loaded plus the child it may spawn; measure it as `VmRSS` in `/proc/<pid>/status` after a request.
+Round down to leave the worker something for what the limit does not count. Then check the result plus
+the footprint against each reaching operation's `memory`.
+
+**`MAGICK_AREA_LIMIT`**: unset. **`MAGICK_THREAD_LIMIT`**: `OMP_NUM_THREADS`, or unset.
+**`MAGICK_TMPDIR`**: unset.
+
+**`policy.xml`**: the same `disk` value.
+
+### A worked example
+
+A production cell serving image transforms and analysis for a Rails application.
+
+**The volume mount.** `/tmp` is a bind mount of a 4G loopback ext4 file on the host, mounted
+`nosuid,nodev,noexec` and chowned to the cell's uid by the host's configuration management:
+
+```yaml
+accessories:
+  active_storage:
+    volumes:
+      - hotcell-sockets:/run/hotcell/cell
+      - /var/lib/hotcell-scratch:/tmp
+    options:
+      cpus: 2
+      memory: 2g
+      memory-swap: 2g
+```
+
+It is disk rather than the scaffold's tmpfs because a tmpfs is RAM charged to the cgroup: every byte of
+scratch is a byte the workers cannot have. It is a dedicated filesystem rather than a named volume or a
+plain directory because the filesystem's size is the cap and its mount flags reach the container; Docker
+can set neither on a bind mount. [docs/DEPLOYMENT.md](DEPLOYMENT.md#a-host-mounted-filesystem) has the recipe.
+
+**The constraints.**
+
+| Input | Value | From |
+| --- | --- | --- |
+| scratch | 4096MiB | the loopback filesystem |
+| container `memory` | 2048MiB | `memory: 2g`, no tmpfs term |
+| `concurrency` | 4 | `config.rb`, twice `cpus` |
+| `transformers.image.vips` | `memory: 1280MB`, `file_size: 768MB` | `file_size` raised in the application's operations file |
+| `analyzers.image.vips` | `memory: 1024MB`, `file_size: 48MB` | gem defaults |
+| `analyzers.image.magick` | `memory: 1024MB`, `file_size: 48MB` | gem defaults |
+| `OMP_NUM_THREADS` | 2 | the image, matching `cpus` |
+| ImageMagick | 6 Q16 | 8 bytes per pixel |
+
+ImageMagick is reached three ways: the vips transformer and analyzer through `magickload`, and the
+magick analyzer through an `identify` child. All three read their input through the descriptor. The
+transformer writes its output on scratch; the analyzers write nothing.
+
+**Disk.** Nothing is staged, so the only thing to hold back is the transformer's output, measured at a
+peak of 256MiB per worker:
+
+    MAGICK_DISK_LIMIT = 4096 ÷ 4 − 256 = 768MiB
+    MAGICK_MAP_LIMIT  = 768MiB
+
+It equals the transformer's `file_size` because that was sized by the same arithmetic, and the
+application's test holds it. Four workers spilling 768MiB and writing 256MiB beside it fill the 4G
+exactly. On the analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill first.
+
+**Memory.**
+
+    per worker          = 2048 ÷ 4 = 512MiB
+    footprint           = 70MiB resident + 12MiB for an `identify` child = 82MiB
+    ceiling             = 512 − 82 = 430MiB
+    MAGICK_MEMORY_LIMIT = 384MiB, the round number under it
+
+Four workers at the limit are `4 × (384 + 82) = 1864MiB` under the 2048MiB cgroup. `384 + 82 = 466MiB`
+sits under the analyzers' 1024MB and the transformer's 1280MB.
+
+**Together.**
+
+    MAGICK_MEMORY_LIMIT = 384MiB
+    MAGICK_MAP_LIMIT    = 768MiB
+    MAGICK_DISK_LIMIT   = 768MiB
+    MAGICK_THREAD_LIMIT = 2
+    MAGICK_AREA_LIMIT   = unset
+
+and `disk` at 768MiB in `policy.xml`.
+
+**What that buys**, at 8 bytes a pixel and summed over every cache open at once:
+
+| Limit | Pixels | For instance |
+| --- | --- | --- |
+| 384MiB heap | 50.3 million | 8192 × 6144 |
+| 768MiB disk | 100.7 million | 16384 × 6144 |
+| both, multi-frame | 151 million | a 20-layer PSD at 2740 × 2740 |
+
+A same-size transform holds source and result, so it decodes half a tier. A larger file is `unreadable`
+on its first request, and the scratch is empty afterwards. The limits the image had inherited from the
+application were `1GiB`, `5GiB` and `10GiB`: memory twice a worker's share of the cgroup, disk two and a
+half times the scratch.
+
+### Checking a built image
+
+Inside the image, as the cell's user, `identify -list resource` prints the effective limits: `Disk`
+should be the number computed, `Area` unbounded. `identify -list policy` shows what `policy.xml` set,
+and that `temporary-path` is absent.
+
+To watch the tiers:
+
+```
+MAGICK_MEMORY_LIMIT=64MiB magick -size 4000x4000 xc:red -debug cache info:
+```
+
+On ImageMagick 6 the command is `convert`.
+
+The cache opens as a file under `MAGICK_TMPDIR`. Raise the size until it passes the disk limit too and
+the command fails with `cache resources exhausted`.
+
+End to end, send a layered file larger than the disk limit through the cell: the answer is
+`unreadable`, and the scratch root is empty afterwards. A cache file left behind means the spill went
+to `/tmp` rather than the request's directory.
+
+### When to recompute
+
+When any input moves: the scratch's size, the container's `memory`, `concurrency`, an operation's
+`file_size` or `memory`, the worker footprint, which operations reach ImageMagick, or the ImageMagick
+build's bytes per pixel. Keep the formulas next to the values in the `Dockerfile`.

--- a/docs/IMAGEMAGICK.md
+++ b/docs/IMAGEMAGICK.md
@@ -134,7 +134,8 @@ the footprint against each reaching operation's `memory`.
 
 A production cell serving image transforms and analysis for a Rails application.
 
-**The volume mount.** `/tmp` is a bind mount of a 4G loopback ext4 file on the host, mounted
+**The volume mount.** `/tmp` is a bind mount of a loopback ext4 image on the host, sized so that `df`
+reports 4096MiB available when the mount is empty, mounted
 `nosuid,nodev,noexec` and chowned to the cell's uid by the host's configuration management:
 
 ```yaml
@@ -158,7 +159,7 @@ can set neither on a bind mount. [docs/DEPLOYMENT.md](DEPLOYMENT.md#a-host-mount
 
 | Input | Value | From |
 | --- | --- | --- |
-| scratch | 4096MiB | the loopback filesystem, taken as fully usable; see the note under "Disk" |
+| scratch | 4096MiB | `df --output=avail` on the empty loopback filesystem |
 | container `memory` | 2048MiB | `memory: 2g`, no tmpfs term |
 | `concurrency` | 4 | `config.rb`, twice `cpus` |
 | cell ceiling | `memory: 1536MB`, `file_size: 768MB` | `config.rb`; an operation's own limits are clamped to these |
@@ -180,10 +181,10 @@ peak of 256MiB per worker:
 
 It equals the transformer's `file_size` because that was sized by the same arithmetic, the
 application's test holds it, and the cell ceiling allows it. Four workers spilling 768MiB and writing
-256MiB beside it fill 4096MiB exactly, so the arithmetic assumes `df --output=avail` on the empty mount
-reports at least 4096MiB, which a 4G image cannot: ext4's metadata takes some of it, and the default 5%
-root reserve takes more, leaving under 3891MiB, for which the same arithmetic gives 716MiB. Check `df` on
-a cell host before taking the number. On the analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill
+256MiB beside it fill the 4096MiB exactly. That is why the scratch input is what `df` reports available
+and not the image's size: ext4's metadata and its default 5% root reserve take part of the image, so a
+4G image reports under 3891MiB, for which the same arithmetic gives 716MiB. Size the image over what the
+arithmetic needs, and take the number from `df` on a cell host. On the analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill
 first.
 
 **Memory.**

--- a/docs/IMAGEMAGICK.md
+++ b/docs/IMAGEMAGICK.md
@@ -158,7 +158,7 @@ can set neither on a bind mount. [docs/DEPLOYMENT.md](DEPLOYMENT.md#a-host-mount
 
 | Input | Value | From |
 | --- | --- | --- |
-| scratch | 4096MiB | the loopback filesystem's nominal size; the usable size is what `df` shows |
+| scratch | 4096MiB | the loopback filesystem, taken as fully usable; see the note under "Disk" |
 | container `memory` | 2048MiB | `memory: 2g`, no tmpfs term |
 | `concurrency` | 4 | `config.rb`, twice `cpus` |
 | cell ceiling | `memory: 1536MB`, `file_size: 768MB` | `config.rb`; an operation's own limits are clamped to these |
@@ -178,10 +178,13 @@ peak of 256MiB per worker:
     MAGICK_DISK_LIMIT = 4096 ÷ 4 − 256 = 768MiB
     MAGICK_MAP_LIMIT  = 768MiB
 
-It equals the transformer's `file_size` because that was sized by the same arithmetic, and the
+It equals the transformer's `file_size` because that was sized by the same arithmetic, the
 application's test holds it, and the cell ceiling allows it. Four workers spilling 768MiB and writing
-256MiB beside it fill the nominal 4G exactly, so the usable size is the number to check with `df`. On the
-analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill first.
+256MiB beside it fill 4096MiB exactly, so the arithmetic assumes the whole 4G is usable: a filesystem made
+with `mkfs.ext4 -m 0`, or an image larger than 4G. On a 4G ext4 with the default 5% root reserve, `df`
+shows about 3891MiB usable and the same arithmetic gives 716MiB. Check `df` on a cell host before taking
+the number. On the analyzer, whose `file_size` is 48MB, a cache file over that takes the `fsize` kill
+first.
 
 **Memory.**
 


### PR DESCRIPTION
Nothing in the docs said what `MAGICK_MEMORY_LIMIT`, `MAGICK_MAP_LIMIT` and `MAGICK_DISK_LIMIT` bound, which of the two ImageMagicks in a cell the environment reaches, or how to size them from the cell's own numbers. An application image carried the limits it had always run in-process — `MAGICK_DISK_LIMIT=10GiB` against a 4G scratch — and on 2026-09-01 one layered PSD filled that scratch on six hosts and convicted 3,393 blobs before anything refused it. Post-mortem: [card 10261975276](https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10261975276).

The first commit is `78f986b8` from #56: `MagickOperation` rebuilds `MiniMagick.cli_env` per request from the worker's `MAGICK_*_LIMIT`, `TMPDIR` and `MAGICK_TMPDIR`. `restricted_env` had dropped them with the rest of the environment, so an image's `MAGICK_DISK_LIMIT` bounded ImageMagick inside libvips and not the `identify` or `magick` behind `analyzers.image.magick` and `transformers.image.magick`, and the request's `TMPDIR` never reached that child either. `magick_environment_test.rb` reads `Disk` back out of a real `magick -list resource` through mini_magick. No setting moves, and the scaffold is untouched.

`docs/IMAGEMAGICK.md` is two parts, descriptive then prescriptive, and covers:

* **The pixel cache** and the memory → map → disk chain the three byte limits divide it into. A cache goes to one tier whole, so a single frame must fit `memory` or `disk` on its own, and a multi-frame file must fit both added together. `MAGICK_AREA_LIMIT` only moves a frame from heap to file and never refuses; `MAGICK_THREAD_LIMIT` is `OMP_NUM_THREADS`; `MAGICK_TMPDIR` is the gem's to set, per request.
* **How ImageMagick reads them**: build default, `policy.xml` as a ceiling the environment can only lower, then the environment, once, at process start.
* **Which ImageMagick in a cell they reach**: both; in-process `magickload` through the worker's environment, and the child through `cli_env`.
* **Why the disk limit is the one that matters**: `file_size` is `RLIMIT_FSIZE`, per file, and cannot bound the sum of twenty cache files.
* **The formulas**: `DISK = scratch ÷ concurrency − staged files`, `MAP = DISK`, `MEMORY = (memory − tmpfs) ÷ concurrency − worker footprint`, checked against every reaching operation's `RLIMIT_DATA`.
* **A worked example** on a production cell, unnamed: the 4G loopback bind mount and why it is disk rather than tmpfs and a capped filesystem rather than a named volume; the constraints (2g cgroup, `concurrency: 4`, `file_size: 768MB` as `4096 ÷ 4 − 256`, descriptor inputs so nothing is staged); and the result, `MEMORY 384MiB`, `DISK 768MiB`, `MAP 768MiB`, `THREAD 2`, `AREA` unset. The disk limit lands on the transformer's `file_size` because both are one worker's share of the spill.
* **Checking a built image** (`identify -list resource`, `-debug cache`, an end-to-end `unreadable` with the scratch empty afterwards) and when to recompute.

`docs/DEPLOYMENT.md` gains a row in the environment table and a bullet under "Making the numbers agree"; the README links the new doc.

Supersedes the sizing section #56 carried, whose worked example was the scaffold's 512m tmpfs and came out at a 16MiB disk limit — arithmetically right and useless as guidance, because the scaffold's scratch is RAM. The example here is a disk-backed scratch, which is what every real deployment runs.

ref: https://app.basecamp.com/2914079/buckets/1666/card_tables/cards/10270096028
