### PR TITLE
Add hotcell --development for a scratch of the cell's own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ gem but are what an operator runs against their own image.
 
 ## next / unreleased
 
+### Upgrading
+
+Some actions that application developers should consider taking when upgrading from an earlier version:
+
+* Add `--development` to the `hotcell` command in `Procfile.dev`, or wherever a cell boots as a plain process beside the application. Without it a cell told no `TMPDIR` sweeps `/tmp` at boot, deleting every file the developer owns there. See the README's "Run it in development".
+
+### HotCell::Server
+
+#### Added
+
+* `hotcell --development`, for a cell booted as a plain process beside the application. The cell never sweeps the directory it is given, `TMPDIR` or the system temporary directory, both shared with everything else a developer runs. Its scratch is `hotcell-<HOTCELL_DIR with slashes as dashes>` beneath it, and it refuses to boot when that name is taken by anything but a directory its uid owns. Before, it swept the developer's `/tmp`, or on macOS the per-user `TMPDIR` every shell sets. An explicit `HOTCELL_WORKSPACE` still has its parent swept. Without the flag nothing changes. `cell.boot` logs the `tmpdir` in use.
+
 ## v0.4.0 / 2026-09-08
 
 ### Upgrading

--- a/README.md
+++ b/README.md
@@ -299,11 +299,15 @@ Add an entry for your cell to `Procfile.dev`:
 
 ```procfile
 web: HOTCELL_ROOT=$PWD/tmp/hotcell-sockets bin/rails server
-cell: BUNDLE_GEMFILE=$PWD/hotcell/Gemfile HOTCELL_CONFIG=$PWD/hotcell/config.rb HOTCELL_OPERATIONS=$PWD/hotcell/operations HOTCELL_DIR=$PWD/tmp/hotcell-sockets/active_storage bundle exec hotcell
+cell: BUNDLE_GEMFILE=$PWD/hotcell/Gemfile HOTCELL_CONFIG=$PWD/hotcell/config.rb HOTCELL_OPERATIONS=$PWD/hotcell/operations HOTCELL_DIR=$PWD/tmp/hotcell-sockets/active_storage bundle exec hotcell --development
 ```
 
 Then `bin/dev` boots both, and the app finds the sockets under `tmp/hotcell-sockets`. At boot the cell
-empties `Dir.tmpdir` of every entry its uid owns.
+empties its `TMPDIR` of every entry its uid owns, and told none it empties the system temporary directory.
+On a developer's machine that is `/tmp`, or on macOS the per-user `TMPDIR` every shell sets, both shared
+with everything else the developer runs. With `--development` the cell never sweeps the directory it is
+given: its scratch is `hotcell-<HOTCELL_DIR with slashes as dashes>` beneath it. `HOTCELL_WORKSPACE`
+defaults under the scratch; pointed elsewhere, its parent is swept too.
 
 #### Configure the cell and operation limits
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -219,7 +219,8 @@ override it.
 | `HOTCELL_DIR` | `/run/hotcell/cell` | Where the cell creates `work.sock` and `control.sock`. The app must use the same directory. |
 | `HOTCELL_OPERATIONS` | `/hotcell/operations` | The directory the cell loads at boot, in sorted order. |
 | `HOTCELL_CONFIG` | `/hotcell/config.rb` | Loaded before the operations, if the file exists. |
-| `HOTCELL_WORKSPACE` | a directory under `Dir.tmpdir` | Where each request's directory is made and removed. On the default accessory this is the tmpfs. Must be absolute. Emptied at boot — see "Where scratch lives". |
+| `HOTCELL_WORKSPACE` | a directory under `TMPDIR` | Where each request's directory is made and removed. On the default accessory this is the tmpfs. Must be absolute. Emptied at boot — see "Where scratch lives". |
+| `TMPDIR` | unset, so `/tmp` | The scratch, emptied at boot of every entry the cell's uid owns. On the accessory `/tmp` is the cell's own mount. Under `hotcell --development` it is only the scratch's parent and is never swept — see "Where scratch lives". |
 | `HOTCELL_HEALTH_TIMEOUT` | `5` | Seconds `hotcell-health` waits for an answer before it reports unhealthy. |
 | `HOME` | `/tmp` | Bundler needs one, and the cell's user has no home directory. A worker replaces it with a directory made for the request and removed with it. |
 | `OMP_NUM_THREADS` | `2` | The OpenMP pool size libvips and ImageMagick use. Match it to `cpus`. See "Bound the OpenMP thread pools". |
@@ -550,10 +551,16 @@ Three layouts, trading the same three things:
 Both disk layouts give up speed, and that is rarely the bottleneck: on NVMe, for spool-and-process
 pipelines, the descriptor design already keeps the biggest bytes off scratch entirely. Both also outlive
 the container, so cleanup stops being the mount's job and becomes the cell's. At boot it empties
-`Dir.tmpdir` and the workspace's parent of every entry its uid owns, `lost+found` excepted, so rebooting
+`TMPDIR` and the workspace's parent of every entry its uid owns, `lost+found` excepted, so rebooting
 the accessory clears a scratch a killed tool filled. A removal that fails is logged as `scratch.unswept`
 and does not stop the boot. The cell refuses to boot if either directory is missing, is reached through a
 symlink its uid owns, or holds `HOTCELL_DIR`.
+
+The rule is the same in every layout, so a cell's `TMPDIR` must be a directory nothing else uses. In the
+container `/tmp` is the cell's own; on a developer's machine it is everyone's, so an uncontainerized cell
+is booted with `hotcell --development`, which never sweeps the directory it is given. Its scratch is a
+directory of its own beneath it, named for `HOTCELL_DIR`. An explicit `HOTCELL_WORKSPACE` has its parent
+swept wherever it points, flag or not.
 
 ### Keeping the tmpfs
 

--- a/examples/devcell
+++ b/examples/devcell
@@ -68,7 +68,7 @@ environment = {
 
 puts "booting exe/hotcell on the example operations"
 pid = Process.spawn(environment, RbConfig.ruby, File.join(REPO, "hotcell-server", "exe", "hotcell"),
-                    out: LOG, err: LOG)
+                    "--development", out: LOG, err: LOG)
 
 begin
   wait_until("the cell's socket") { File.socket?(SOCKETS.first) }

--- a/hotcell-server/exe/hotcell
+++ b/hotcell-server/exe/hotcell
@@ -3,9 +3,13 @@
 
 require "hot_cell/server"
 
+development = ARGV.delete("--development") ? true : false
+abort "usage: hotcell [--development]" unless ARGV.empty?
+
 HotCell.load!
 
 HotCell::Supervisor
-  .new(directory: ENV.fetch("HOTCELL_DIR", "/run/hotcell/cell"), workspace: ENV["HOTCELL_WORKSPACE"])
+  .new(directory: ENV.fetch("HOTCELL_DIR", "/run/hotcell/cell"), workspace: ENV["HOTCELL_WORKSPACE"],
+       development: development)
   .boot
   .run

--- a/hotcell-server/lib/hot_cell/supervisor.rb
+++ b/hotcell-server/lib/hot_cell/supervisor.rb
@@ -138,9 +138,10 @@ module HotCell
 
     attr_reader :configuration, :counters, :log, :directory, :workspace
 
-    def initialize(directory:, workspace: nil, configuration: HotCell.configuration, log: Log.new,
-                   ptrace_scope_path: PTRACE_SCOPE)
+    def initialize(directory:, workspace: nil, development: false, configuration: HotCell.configuration,
+                   log: Log.new, ptrace_scope_path: PTRACE_SCOPE)
       @directory = directory
+      @development_tmpdir = own_tmpdir if development
       @workspace = workspace || File.join(tmpdir, "hotcell-workspace")
       @configuration = configuration
       @log = log
@@ -156,6 +157,7 @@ module HotCell
       verify_socket_paths!
       verify_limits!
       verify_ptrace_scope!
+      claim_tmpdir if @development_tmpdir
       verify_scratches!
       prepare_directories
       preload
@@ -164,7 +166,7 @@ module HotCell
       @control_handler = Control.new(configuration: configuration, counters: counters)
       trap_signals
 
-      log.write "cell.boot", pid: Process.pid, directory: directory, operations: Registry.names,
+      log.write "cell.boot", pid: Process.pid, directory: directory, tmpdir: tmpdir, operations: Registry.names,
                              configuration: configuration.to_h
       self
     end
@@ -1032,8 +1034,56 @@ module HotCell
       # `Dir.tmpdir` with its fallbacks removed: it answers `.` for a `/tmp` its owner cannot write, and a
       # worker can leave `/tmp` in that state. The sweep is what puts the mode back, so it has to see the
       # directory `Dir.tmpdir` will answer once it has.
+      #
+      # A cell told no `TMPDIR` sweeps the system's: right on the accessory, whose `/tmp` is its own mount, and
+      # wrong on a developer's machine, where `/tmp` and macOS's per-user `TMPDIR` are shared with everything
+      # else the developer runs. So `--development` never sweeps the directory it is given, unless an explicit
+      # workspace makes it the workspace's parent. Its scratch is a directory of its own beneath it, named for
+      # the socket directory so two cells one uid runs do not sweep each other's slots, and chosen once here so
+      # the default workspace and the boot agree.
       def tmpdir
-        ENV.values_at("TMPDIR", "TMP", "TEMP").compact.reject(&:empty?).first || Etc.systmpdir
+        @development_tmpdir || configured_tmpdir || Etc.systmpdir
+      end
+
+      def configured_tmpdir
+        ENV.values_at("TMPDIR", "TMP", "TEMP").compact.reject(&:empty?).first
+      end
+
+      def own_tmpdir
+        parent = configured_tmpdir || Etc.systmpdir
+        File.expand_path File.join(parent, "hotcell-#{directory.delete_prefix("/").tr("/", "-")}")
+      end
+
+      # The parent is world-writable, so the name is claimed with `mkdir` and, when it exists, read back with
+      # `lstat`: it has to be a plain directory this uid owns. Its mode goes back to `0700` because the sticky
+      # parent stops another uid from replacing the directory, not from writing inside one a worker opened up.
+      # The ancestors are checked before `mkdir` and `chmod` could act through an owned symlink;
+      # `verify_scratches!` checks them again. `ENV["TMPDIR"]` is left alone: the supervisor writes no temporary
+      # files, a worker sets its own per request, and a second supervisor in this process would nest its
+      # scratch inside this one.
+      #
+      # Accepted: an entry another uid plants inside, once a worker has opened the directory up, survives the
+      # sweep, which removes only what this uid owns, and a slot follows it. Opening it up needs code already
+      # running as this uid, which can reach the same files directly.
+      def claim_tmpdir
+        claimed = tmpdir
+        if (link = owned_symlink_on(File.dirname(claimed)))
+          raise ConfigurationError, "#{link} is a symlink the cell's uid owns, on the path to the scratch " \
+                                    "#{claimed}, and a boot sweeps the scratch"
+        end
+
+        begin
+          Dir.mkdir claimed, 0o700
+        rescue Errno::EEXIST
+          stat = File.lstat(claimed)
+          unless stat.directory? && stat.uid == Process.uid
+            raise ConfigurationError, "#{claimed} is not a directory this uid owns, and a boot sweeps it. Set " \
+                                      "TMPDIR to a directory of the cell's own."
+          end
+          File.chmod 0o700, claimed
+        end
+      rescue SystemCallError => error
+        raise ConfigurationError, "the scratch #{claimed} could not be claimed: #{error.message}"
       end
 
       def scratches

--- a/hotcell-server/lib/hot_cell/test_cell.rb
+++ b/hotcell-server/lib/hot_cell/test_cell.rb
@@ -45,7 +45,8 @@ module HotCell
     end
 
     # Anything in `supervisor:` goes to Supervisor.new; everything else is the cell's own limits.
-    def initialize(name: "test", supervisor: {}, operations: nil, **options)
+    # `own_tmpdir: false` boots the cell with no `TMPDIR` at all, the way a Procfile that sets none does.
+    def initialize(name: "test", supervisor: {}, operations: nil, own_tmpdir: true, **options)
       @name = name
       @supervisor_options = supervisor
       @operations = operations
@@ -54,8 +55,8 @@ module HotCell
       @directory = File.join(@root, name)
       # Boot empties `Dir.tmpdir` and the workspace's parent of what this uid owns. Inside the cell both are
       # this directory, so the sweep reaches neither the developer's `/tmp` nor the log and sockets beside it.
-      @tmpdir = File.join(@root, "tmp")
-      @workspace = File.join(@tmpdir, "workspace")
+      @tmpdir = File.join(@root, "tmp") if own_tmpdir
+      @workspace = File.join(@tmpdir, "workspace") if own_tmpdir
       @log_path = File.join(@root, "cell.log")
     end
 
@@ -78,8 +79,12 @@ module HotCell
 
         HotCell.limits(**@options) unless @options.empty?
 
-        FileUtils.mkdir_p @tmpdir
-        ENV["TMPDIR"] = @tmpdir
+        if @tmpdir
+          FileUtils.mkdir_p @tmpdir
+          ENV["TMPDIR"] = @tmpdir
+        else
+          %w[ TMPDIR TMP TEMP ].each { |key| ENV.delete key }
+        end
 
         supervisor = Supervisor.new(directory: directory, workspace: workspace,
                                     log: Log.new(File.open(log_path, "w")), **@supervisor_options)

--- a/hotcell-server/test/scratch_test.rb
+++ b/hotcell-server/test/scratch_test.rb
@@ -197,7 +197,180 @@ class ScratchTest < RegistryIsolatedTest
     end
   end
 
+  # Without `--development` a cell told no `TMPDIR` sweeps the system's, which the accessory needs.
+  def test_a_cell_told_no_tmpdir_sweeps_the_system_tmpdir
+    File.write File.join(@elsewhere, "magick-abc123"), "pixel cache"
+
+    with_system_tmpdir @elsewhere do
+      boot TestCell.new(own_tmpdir: false), workspace: nil
+    end
+
+    refute File.exist?(File.join(@elsewhere, "magick-abc123"))
+  end
+
+  def test_a_development_cell_told_no_tmpdir_leaves_the_system_tmpdir_alone_and_works_in_a_directory_of_its_own
+    File.write File.join(@elsewhere, "keep"), "not the cell's"
+
+    with_system_tmpdir @elsewhere do
+      boot development_cell, workspace: nil do |cell|
+        assert_ok cell.call("test.echo")
+      end
+    end
+
+    assert File.exist?(File.join(@elsewhere, "keep"))
+    own = Dir.children(@elsewhere) - [ "keep" ]
+    assert_equal 1, own.size
+    assert Dir.exist?(File.join(@elsewhere, own.first, "hotcell-workspace"))
+  end
+
+  # A macOS shell hands every process a per-user `TMPDIR`, so a `TMPDIR` the cell is told is as shared as the
+  # system's.
+  def test_a_development_cell_told_a_tmpdir_leaves_it_alone_and_works_in_a_directory_of_its_own_under_it
+    cell = TestCell.new(supervisor: { development: true })
+    FileUtils.mkdir_p cell.tmpdir
+    File.write File.join(cell.tmpdir, "keep"), "not the cell's"
+
+    with_system_tmpdir @elsewhere do
+      boot cell, workspace: nil do
+        assert_ok cell.call("test.echo")
+        assert File.exist?(File.join(cell.tmpdir, "keep"))
+        own = Dir.children(cell.tmpdir) - [ "keep" ]
+        assert_equal 1, own.size
+        assert Dir.exist?(File.join(cell.tmpdir, own.first, "hotcell-workspace"))
+      end
+    end
+
+    assert_empty Dir.children(@elsewhere)
+  end
+
+  def test_the_directory_of_its_own_is_the_same_at_the_next_boot_and_is_swept
+    cell = development_cell
+    cell.instance_variable_get(:@supervisor_options)[:workspace] = nil
+
+    with_system_tmpdir @elsewhere do
+      cell.start
+      cell.stop
+      own = File.join(@elsewhere, Dir.children(@elsewhere).first)
+      File.write File.join(own, "magick-abc123"), "pixel cache"
+
+      cell.start
+      cell.stop
+
+      assert_equal [ own ], Dir.children(@elsewhere).map { |name| File.join(@elsewhere, name) }
+      refute File.exist?(File.join(own, "magick-abc123"))
+    end
+  ensure
+    cell&.stop
+    cell&.cleanup
+  end
+
+  # Two cells one uid runs must not sweep each other's slots, so the directory is the socket directory's.
+  def test_two_development_cells_told_no_tmpdir_get_directories_of_their_own
+    with_system_tmpdir @elsewhere do
+      boot development_cell, workspace: nil
+      boot development_cell, workspace: nil
+    end
+
+    assert_equal 2, Dir.children(@elsewhere).size
+  end
+
+  # The sticky parent stops another uid from replacing the directory, not from writing inside one a worker
+  # left world-writable.
+  def test_a_directory_of_its_own_left_open_is_closed_again
+    cell = development_cell
+    cell.instance_variable_get(:@supervisor_options)[:workspace] = nil
+
+    with_system_tmpdir @elsewhere do
+      cell.start
+      cell.stop
+      own = File.join(@elsewhere, Dir.children(@elsewhere).first)
+      File.chmod 0o777, own
+
+      cell.start
+      cell.stop
+
+      assert_equal 0o700, File.stat(own).mode & 0o777
+    end
+  ensure
+    cell&.stop
+    cell&.cleanup
+  end
+
+  def test_a_symlink_at_the_name_of_the_directory_of_its_own_refuses_to_boot
+    cell = development_cell
+    cell.instance_variable_get(:@supervisor_options)[:workspace] = nil
+
+    Dir.mktmpdir "hotcell-target" do |target|
+      File.write File.join(target, "keep"), "not the cell's"
+
+      with_system_tmpdir @elsewhere do
+        cell.start
+        cell.stop
+        own = File.join(@elsewhere, Dir.children(@elsewhere).first)
+        FileUtils.rm_rf own
+        File.symlink target, own
+
+        error = assert_raises(RuntimeError) { cell.start }
+
+        assert_match "is not a directory this uid owns", error.message
+      end
+
+      assert File.exist?(File.join(target, "keep"))
+    end
+  ensure
+    cell&.stop
+    cell&.cleanup
+  end
+
+  def test_a_system_tmpdir_reached_through_a_symlink_the_cell_owns_refuses_to_boot_before_touching_it
+    link = File.join(@elsewhere, "link")
+    Dir.mktmpdir "hotcell-target" do |target|
+      File.symlink target, link
+
+      error = with_system_tmpdir(link) { assert_raises(RuntimeError) { boot development_cell, workspace: nil } }
+
+      assert_match "is a symlink the cell's uid owns", error.message
+      assert_empty Dir.children(target)
+    end
+  end
+
+  def test_a_name_something_else_took_first_refuses_to_boot
+    cell = development_cell
+    cell.instance_variable_get(:@supervisor_options)[:workspace] = nil
+
+    with_system_tmpdir @elsewhere do
+      cell.start
+      cell.stop
+      own = File.join(@elsewhere, Dir.children(@elsewhere).first)
+      FileUtils.rm_rf own
+      File.write own, "was here first"
+
+      error = assert_raises(RuntimeError) { cell.start }
+
+      assert_match "is not a directory this uid owns", error.message
+    end
+  ensure
+    cell&.stop
+    cell&.cleanup
+  end
+
   private
+    def development_cell
+      TestCell.new(own_tmpdir: false, supervisor: { development: true })
+    end
+
+    # The cell forks from this process, so a stub installed here is inherited by the supervisor. The method
+    # is removed before it is redefined, since a redefinition is a warning under `-w`.
+    def with_system_tmpdir(path)
+      original = Etc.method(:systmpdir)
+      Etc.singleton_class.remove_method :systmpdir
+      Etc.define_singleton_method(:systmpdir) { path }
+      yield
+    ensure
+      Etc.singleton_class.remove_method :systmpdir
+      Etc.define_singleton_method(:systmpdir, original)
+    end
+
     def boot(cell, workspace:)
       cell.instance_variable_get(:@supervisor_options)[:workspace] = workspace
       cell.start
@@ -207,7 +380,6 @@ class ScratchTest < RegistryIsolatedTest
       cell.cleanup
     end
 
-    # The cell forks from this process, so a stub installed here is inherited by the supervisor.
     def stub_remove_entry_to_fail
       original = FileUtils.method(:remove_entry)
       FileUtils.define_singleton_method(:remove_entry) { |*| raise Errno::ENOTEMPTY, "induced" }


### PR DESCRIPTION
Since [#52](https://github.com/basecamp/hotcell/pull/52) a cell told no `TMPDIR` takes `Etc.systmpdir` and empties it at boot. On the accessory that is the cell's own mount and has to start empty. On a developer's machine it is `/tmp`, so a `Procfile.dev` that set no `TMPDIR`, which is what the README showed and what `bc3` and `fizzy` have today, deleted every file the developer owned there on every `bin/dev`. Discussion on [the card](https://app.fizzy.do/5986089/cards/5272).

`hotcell` gains a `--development` flag, passed to the supervisor as `development: true`. With it the cell never sweeps the directory it is given. Whatever `TMPDIR`, `TMP`, `TEMP` or `Etc.systmpdir` resolves to, the cell makes `hotcell-<HOTCELL_DIR with slashes as dashes>` beneath it, mode `0700`, and sweeps only that. This is what makes it work the same on Linux, where a shell sets no `TMPDIR`, and on macOS, where every shell sets a per-user one that is just as shared. `HOTCELL_WORKSPACE` still defaults under the scratch, so the scratch is one directory; pointed elsewhere, its parent is swept as on `master`. The name comes from `HOTCELL_DIR` rather than the uid so two cells one developer runs do not sweep each other's slots.

The parent is world-writable, so the claim is defensive: an owned symlink anywhere on the path is refused before `mkdir` or `chmod` touch anything; an existing entry at the name must be a plain directory this uid owns, and is reset to exactly `0700` so a mode a worker opened up does not survive a reboot; any `SystemCallError` on the way is a `ConfigurationError`. `cell.boot` logs the `tmpdir` in use. The choice is made once, at `new`, so the default workspace and the boot agree.

Without the flag nothing changes: a cell told no `TMPDIR` sweeps the system's, `/tmp` included, and the `tmpdir` expression is `master`'s. Production is untouched.

Codex adversarial review ran six rounds on [the card](https://app.fizzy.do/5986089/cards/5272); the defensive claim above and the macOS behaviour came out of it. One finding is accepted and recorded in the `claim_tmpdir` comment: an entry another uid plants inside the private directory after a compromised worker opened it up survives the sweep, which gives that attacker nothing the compromised worker did not already hold.

Tests in `scratch_test.rb`, booting with `TestCell`'s new `own_tmpdir: false` and a stubbed `Etc.systmpdir`. Without the flag a cell told no `TMPDIR` still sweeps the system tmpdir. With it: a cell told no `TMPDIR` leaves the system tmpdir alone and works beneath it; a cell told a `TMPDIR` leaves that alone and works beneath it; the directory is the same at the next boot and is swept; two cells get two directories; a `0777` directory comes back `0700`; a file, a symlink, or an owned symlink on the path refuses to boot without touching the target. Docs: the README `Procfile.dev` line and `examples/devcell` gain `--development`, the `TMPDIR` row and "Where scratch lives" in `docs/DEPLOYMENT.md`, and the changelog under unreleased with an `Upgrading` action to add the flag wherever a dev cell boots. `VERSION` is already `0.5.0.dev`, so no bump.

ref: https://app.fizzy.do/5986089/cards/5272

🤖 Generated with [Claude Code](https://claude.com/claude-code)
